### PR TITLE
fixed compile error, @Override annotation not allowed interface method on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.msgpack</groupId>
   <artifactId>msgpack</artifactId>
   <name>MessagePack for Java</name>
-  <description>MessagePack for Java is a binary-based efficient object 
+  <description>MessagePack for Java is a binary-based efficient object
       serialization library in Java.</description>
   <version>0.6.3-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -93,8 +93,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
fixed compile error, @Override annotation not allowed interface method on java5.
