### PR TITLE
modify TemplateRegistry::lookup

### DIFF
--- a/src/test/java/org/msgpack/template/TestTemplateRegistry.java
+++ b/src/test/java/org/msgpack/template/TestTemplateRegistry.java
@@ -35,4 +35,52 @@ public class TestTemplateRegistry {
         assertThat(template, is(instanceOf(ListTemplate.class)));
     }
 
+    // Iface2 < Iface1
+    static interface Iface0 {}
+    static interface Iface1 extends Iface0 {}
+    static interface Iface2 extends Iface1 {}
+
+    static class ImplementsIface0 implements Iface0 {}
+    static class ImplementsIface1 implements Iface1 {}
+    static class ImplementsIface2 implements Iface2 {}
+
+    static class Iface0Template extends UnsupportedOperationTemplate<Iface0> {}
+    static class Iface1Template extends UnsupportedOperationTemplate<Iface1> {}
+    static class Iface2Template extends UnsupportedOperationTemplate<Iface2> {}
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testCanLookupByInheritanceHierarchy() throws Exception {
+        TemplateRegistry registry = new TemplateRegistry(null);
+        registry.register(Iface0.class, new Iface0Template());
+
+        // Iface0 == Iface0
+        Template<Iface0> template = registry.lookup(Iface0.class);
+        assertThat(template, is(instanceOf(Iface0Template.class)));
+
+        // ImplementsIface2 (< Iface2 < Iface1) < Iface0
+        template = registry.lookup(ImplementsIface2.class);
+        assertThat(template, is(instanceOf(Iface0Template.class)));
+
+        // ImplementsIface1 (< Iface1) < Iface0
+        template = registry.lookup(ImplementsIface1.class);
+        assertThat(template, is(instanceOf(Iface0Template.class)));
+
+        // ImplementsIface0 < Iface0
+        template = registry.lookup(ImplementsIface0.class);
+        assertThat(template, is(instanceOf(Iface0Template.class)));
+
+        // register specialized (override) templates and lookup again
+        registry.register(ImplementsIface1.class, new Iface1Template());
+        registry.register(ImplementsIface2.class, new Iface2Template());
+
+        template = registry.lookup(ImplementsIface2.class);
+        assertThat(template, is(instanceOf(Iface2Template.class)));
+
+        template = registry.lookup(ImplementsIface1.class);
+        assertThat(template, is(instanceOf(Iface1Template.class)));
+
+        template = registry.lookup(ImplementsIface0.class);
+        assertThat(template, is(instanceOf(Iface0Template.class)));
+    }
 }

--- a/src/test/java/org/msgpack/template/UnsupportedOperationTemplate.java
+++ b/src/test/java/org/msgpack/template/UnsupportedOperationTemplate.java
@@ -1,0 +1,29 @@
+package org.msgpack.template;
+
+import java.io.IOException;
+
+import org.msgpack.packer.Packer;
+import org.msgpack.unpacker.Unpacker;
+
+public class UnsupportedOperationTemplate<T> implements Template<T> {
+
+    @Override
+    public void write(Packer pk, T v) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(Packer pk, T v, boolean required) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T read(Unpacker u, T to) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T read(Unpacker u, T to, boolean required) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
In the following class structure(deep class hierarchy), TempalteRegistry::lookup can not lookup template correctly:

```
interface Iface0 {}
interface Iface1 extends Iface0 {}
interface Iface2 extends Iface1 {}
```
