### PR TITLE
Workaround a crash on Android

### DIFF
--- a/src/main/java/org/msgpack/template/builder/AbstractTemplateBuilder.java
+++ b/src/main/java/org/msgpack/template/builder/AbstractTemplateBuilder.java
@@ -43,6 +43,7 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.builder.TemplateBuildException;
 
 public abstract class AbstractTemplateBuilder implements TemplateBuilder {
+    private static boolean hasJavassist = true;
 
     protected TemplateRegistry registry;
 
@@ -72,10 +73,15 @@ public abstract class AbstractTemplateBuilder implements TemplateBuilder {
     protected abstract <T> Template<T> buildTemplate(Class<T> targetClass, FieldEntry[] entries);
 
     protected void checkClassValidation(final Class<?> targetClass) {
-        if (javassist.Modifier.isAbstract(targetClass.getModifiers())) {
-            throw new TemplateBuildException(
-                    "Cannot build template for abstract class: " + targetClass.getName());
+        try {
+            if (hasJavassist && javassist.Modifier.isAbstract(targetClass.getModifiers())) {
+                throw new TemplateBuildException(
+                        "Cannot build template for abstract class: " + targetClass.getName());
+            }
+        } catch (NoClassDefFoundError e) {
+            hasJavassist = false;
         }
+        
         if (targetClass.isInterface()) {
             throw new TemplateBuildException(
                     "Cannot build template for interface: " + targetClass.getName());

--- a/src/main/java/org/msgpack/template/builder/TemplateBuilderChain.java
+++ b/src/main/java/org/msgpack/template/builder/TemplateBuilderChain.java
@@ -51,17 +51,16 @@ public class TemplateBuilderChain {
             throw new NullPointerException("registry is null");
         }
 
-        // forceBuilder
-        forceBuilder = new JavassistTemplateBuilder(registry);
-        if (cl != null) {
-            ((JavassistTemplateBuilder) forceBuilder).addClassLoader(cl);
-        }
-
         // builder
         TemplateBuilder builder;
         templateBuilders.add(new ArrayTemplateBuilder(registry));
         templateBuilders.add(new OrdinalEnumTemplateBuilder(registry));
         if (enableDynamicCodeGeneration()) { // use dynamic code generation
+            forceBuilder = new JavassistTemplateBuilder(registry);
+            if (cl != null) {
+                ((JavassistTemplateBuilder) forceBuilder).addClassLoader(cl);
+            }
+
             builder = forceBuilder;
             templateBuilders.add(builder);
             // FIXME #MN next version
@@ -69,7 +68,8 @@ public class TemplateBuilderChain {
             // JavassistBeansTemplateBuilder(registry));
             templateBuilders.add(new ReflectionBeansTemplateBuilder(registry));
         } else { // use reflection
-            builder = new ReflectionTemplateBuilder(registry);
+            forceBuilder = new ReflectionTemplateBuilder(registry);
+            builder = forceBuilder;
             templateBuilders.add(builder);
             templateBuilders.add(new ReflectionBeansTemplateBuilder(registry));
         }


### PR DESCRIPTION
msgpack-java was crashed on Android when accessing javassist's classes. This commit works around the crash.
