### PR TITLE
Support maven-findbugs-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,15 @@
           <argLine>-Xmx512M</argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <configuration>
+          <findbugsXmlOutput>true</findbugsXmlOutput>
+          <xmlOutput>true</xmlOutput>
+          <effort>Max</effort>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
FindBugs is a static analyser to look for bugs in Java code.
This change enable mspgack-java to analyse potential bugs by
using FindBugs.

To use findbugs, please type

```
$ mvn findbugs:findbugs
```

Signed-off-by: Tsuyoshi Ozawa ozawa.tsuyoshi@gmail.com
