### PR TITLE
Add addClassLoader method to JavassistTemplateBuilder

### DIFF
--- a/src/main/java/org/msgpack/template/builder/JavassistTemplateBuilder.java
+++ b/src/main/java/org/msgpack/template/builder/JavassistTemplateBuilder.java
@@ -17,7 +17,6 @@
 //
 package org.msgpack.template.builder;
 
-import java.lang.Thread;
 import java.lang.reflect.Type;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -88,6 +87,10 @@ public class JavassistTemplateBuilder extends AbstractTemplateBuilder {
             LOG.fine("matched type: " + targetClass.getName());
         }
         return matched;
+    }
+    
+    public void addClassLoader(ClassLoader cl) {
+    	pool.appendClassPath(new LoaderClassPath(cl));
     }
 
     protected CtClass makeCtClass(String className) {


### PR DESCRIPTION
The commit 364c4737699411ab6f530e7a7a485a81ada17a13 removed
addClassLoader method.
The method addClassLoader should come back again, because
this method seems to be still useful and is used in some
applications(e.g. msgpack-scala).

Signed-off-by: Tsuyoshi Ozawa ozawa.tsuyoshi@gmail.com
