### PR TITLE
MessagePack For Android - dependency fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
+	<exclusions>
+		<exclusion>
+			<artifactId>junit</artifactId>
+			<groupId>junit</groupId>
+		</exclusion>
+	</exclusions>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>


### PR DESCRIPTION
json-simple, through a transitive dependency (see commit for details), causes Android Maven builds to fail. This adds a fix.
