### PR TITLE
Slightly better type errors for Unpackers.

### DIFF
--- a/src/main/java/org/msgpack/unpacker/Accept.java
+++ b/src/main/java/org/msgpack/unpacker/Accept.java
@@ -23,40 +23,46 @@ import org.msgpack.io.BufferReferer;
 import org.msgpack.MessageTypeException;
 
 abstract class Accept implements BufferReferer {
+    private final String expected;
+
+    Accept(String expected) {
+        this.expected = expected;
+    }
+
     void acceptBoolean(boolean v) throws IOException {
-        throw new MessageTypeException("Unexpected boolean value");
+        throw new MessageTypeException(String.format("Expected %s, but got boolean", expected));
     }
 
     void acceptInteger(byte v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptInteger(short v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptInteger(int v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptInteger(long v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptUnsignedInteger(byte v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptUnsignedInteger(short v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptUnsignedInteger(int v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     void acceptUnsignedInteger(long v) throws IOException {
-        throw new MessageTypeException("Unexpected integer value");
+        throw new MessageTypeException(String.format("Expected %s, but got integer value", expected));
     }
 
     // void checkRawAcceptable() throws IOException {
@@ -64,11 +70,11 @@ abstract class Accept implements BufferReferer {
     // }
 
     void acceptRaw(byte[] raw) throws IOException {
-        throw new MessageTypeException("Unexpected raw value");
+        throw new MessageTypeException(String.format("Expected %s, but got raw value", expected));
     }
 
     void acceptEmptyRaw() throws IOException {
-        throw new MessageTypeException("Unexpected raw value");
+        throw new MessageTypeException(String.format("Expected %s, but got raw value", expected));
     }
 
     // void checkArrayAcceptable(int size) throws IOException {
@@ -76,7 +82,7 @@ abstract class Accept implements BufferReferer {
     // }
 
     void acceptArray(int size) throws IOException {
-        throw new MessageTypeException("Unexpected array value");
+        throw new MessageTypeException(String.format("Expected %s, but got array value", expected));
     }
 
     // void checkMapAcceptable(int size) throws IOException {
@@ -84,22 +90,22 @@ abstract class Accept implements BufferReferer {
     // }
 
     void acceptMap(int size) throws IOException {
-        throw new MessageTypeException("Unexpected map value");
+        throw new MessageTypeException(String.format("Expected %s, but got map value", expected));
     }
 
     void acceptNil() throws IOException {
-        throw new MessageTypeException("Unexpected nil value");
+        throw new MessageTypeException(String.format("Expected %s, but got nil value", expected));
     }
 
     void acceptFloat(float v) throws IOException {
-        throw new MessageTypeException("Unexpected float value");
+        throw new MessageTypeException(String.format("Expected %s, but got float value", expected));
     }
 
     void acceptDouble(double v) throws IOException {
-        throw new MessageTypeException("Unexpected float value");
+        throw new MessageTypeException(String.format("Expected %s, but got float value", expected));
     }
 
     public void refer(ByteBuffer bb, boolean gift) throws IOException {
-        throw new MessageTypeException("Unexpected raw value");
+        throw new MessageTypeException(String.format("Expected %s, but got raw value", expected));
     }
 }

--- a/src/main/java/org/msgpack/unpacker/ArrayAccept.java
+++ b/src/main/java/org/msgpack/unpacker/ArrayAccept.java
@@ -20,6 +20,10 @@ package org.msgpack.unpacker;
 final class ArrayAccept extends Accept {
     int size;
 
+    ArrayAccept() {
+        super("array");
+    }
+
     @Override
     void acceptArray(int size) {
         this.size = size;

--- a/src/main/java/org/msgpack/unpacker/BigIntegerAccept.java
+++ b/src/main/java/org/msgpack/unpacker/BigIntegerAccept.java
@@ -22,6 +22,10 @@ import java.math.BigInteger;
 final class BigIntegerAccept extends Accept {
     BigInteger value;
 
+    BigIntegerAccept() {
+        super("integer");
+    }
+
     @Override
     void acceptInteger(byte v) {
         this.value = BigInteger.valueOf((long) v);

--- a/src/main/java/org/msgpack/unpacker/ByteArrayAccept.java
+++ b/src/main/java/org/msgpack/unpacker/ByteArrayAccept.java
@@ -23,6 +23,10 @@ import java.nio.ByteBuffer;
 final class ByteArrayAccept extends Accept {
     byte[] value;
 
+    ByteArrayAccept() {
+        super("raw value");
+    }
+
     @Override
     void acceptRaw(byte[] raw) {
         this.value = raw;

--- a/src/main/java/org/msgpack/unpacker/DoubleAccept.java
+++ b/src/main/java/org/msgpack/unpacker/DoubleAccept.java
@@ -20,6 +20,10 @@ package org.msgpack.unpacker;
 final class DoubleAccept extends Accept {
     double value;
 
+    DoubleAccept() {
+        super("float");
+    }
+
     void acceptFloat(float v) {
         this.value = (double) v;
     }

--- a/src/main/java/org/msgpack/unpacker/IntAccept.java
+++ b/src/main/java/org/msgpack/unpacker/IntAccept.java
@@ -22,6 +22,10 @@ import org.msgpack.MessageTypeException;
 final class IntAccept extends Accept {
     int value;
 
+    IntAccept() {
+        super("integer");
+    }
+
     @Override
     void acceptInteger(byte v) {
         this.value = (int) v;

--- a/src/main/java/org/msgpack/unpacker/LongAccept.java
+++ b/src/main/java/org/msgpack/unpacker/LongAccept.java
@@ -22,6 +22,10 @@ import org.msgpack.MessageTypeException;
 final class LongAccept extends Accept {
     long value;
 
+    LongAccept() {
+        super("integer");
+    }
+
     @Override
     void acceptInteger(byte v) {
         this.value = (long) v;

--- a/src/main/java/org/msgpack/unpacker/MapAccept.java
+++ b/src/main/java/org/msgpack/unpacker/MapAccept.java
@@ -20,6 +20,10 @@ package org.msgpack.unpacker;
 final class MapAccept extends Accept {
     int size;
 
+    MapAccept() {
+        super("map");
+    }
+
     @Override
     void acceptMap(int size) {
         this.size = size;

--- a/src/main/java/org/msgpack/unpacker/SkipAccept.java
+++ b/src/main/java/org/msgpack/unpacker/SkipAccept.java
@@ -21,6 +21,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 final class SkipAccept extends Accept {
+    SkipAccept() {
+        super(null);
+    }
+
     @Override
     void acceptBoolean(boolean v) {
     }

--- a/src/main/java/org/msgpack/unpacker/StringAccept.java
+++ b/src/main/java/org/msgpack/unpacker/StringAccept.java
@@ -30,6 +30,7 @@ final class StringAccept extends Accept {
     private CharsetDecoder decoder;
 
     public StringAccept() {
+        super("raw value");
         this.decoder = Charset.forName("UTF-8").newDecoder()
                 .onMalformedInput(CodingErrorAction.REPORT)
                 .onUnmappableCharacter(CodingErrorAction.REPORT);

--- a/src/main/java/org/msgpack/unpacker/ValueAccept.java
+++ b/src/main/java/org/msgpack/unpacker/ValueAccept.java
@@ -26,6 +26,10 @@ import org.msgpack.packer.Unconverter;
 final class ValueAccept extends Accept {
     private Unconverter uc = null;
 
+    ValueAccept() {
+        super(null);
+    }
+
     void setUnconverter(Unconverter uc) throws IOException {
         this.uc = uc;
     }


### PR DESCRIPTION
Basically just changes type-related error messages in Accept such that you get a little more detail about what was expected in the token stream vs. what we actually saw. Naive implementation, but this sort of detail is really helpful when trying to debug production issues.
