### PR TITLE
Replaced testShort with testByte in testByte function.

### DIFF
--- a/src/test/java/org/msgpack/TestSet.java
+++ b/src/test/java/org/msgpack/TestSet.java
@@ -42,9 +42,9 @@ public class TestSet {
     }
 
     public void testByte() throws Exception {
-	testShort((byte) 0);
-	testShort((byte) -1);
-	testShort((byte) 1);
+	testByte((byte) 0);
+	testByte((byte) -1);
+	testByte((byte) 1);
 	testByte(Byte.MIN_VALUE);
 	testByte(Byte.MAX_VALUE);
 	byte[] bytes = new byte[1000];


### PR DESCRIPTION
https://github.com/msgpack/msgpack-java/blob/master/src/test/java/org/msgpack/TestSet.java#L45
Line 45 to 47 calls testShort in testByte function.
I think that testByte should by called instead of testShort.
