### PR TITLE
Patch: an interface also has the abstract modifier, so in order to corre...

### DIFF
--- a/src/main/java/org/msgpack/template/builder/AbstractTemplateBuilder.java
+++ b/src/main/java/org/msgpack/template/builder/AbstractTemplateBuilder.java
@@ -72,13 +72,13 @@ public abstract class AbstractTemplateBuilder implements TemplateBuilder {
     protected abstract <T> Template<T> buildTemplate(Class<T> targetClass, FieldEntry[] entries);
 
     protected void checkClassValidation(final Class<?> targetClass) {
-        if (Modifier.isAbstract(targetClass.getModifiers())) {
-            throw new TemplateBuildException(
-                    "Cannot build template for abstract class: " + targetClass.getName());
-        }
         if (targetClass.isInterface()) {
             throw new TemplateBuildException(
                     "Cannot build template for interface: " + targetClass.getName());
+        }
+        if (Modifier.isAbstract(targetClass.getModifiers())) {
+            throw new TemplateBuildException(
+                    "Cannot build template for abstract class: " + targetClass.getName());
         }
         if (targetClass.isArray()) {
             throw new TemplateBuildException(


### PR DESCRIPTION
...ctly check if a passed in type is an interface, should check for interface modifier before checking for abstract modifier
