### PR TITLE
Add findbugs report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.5.3</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Added the configuration of Findbugs report. We can use it to find problems like this:

```
$ mvn clean compile findbugs:check
      :
[INFO] >>> findbugs-maven-plugin:2.5.2:check (default-cli) @ msgpack-core >>>
[INFO]
[INFO] --- findbugs-maven-plugin:2.5.2:findbugs (findbugs) @ msgpack-core ---
[INFO] Fork Value is true
     [java] Warnings generated: 1
[INFO] Done FindBugs Analysis....
[INFO]
[INFO] <<< findbugs-maven-plugin:2.5.2:check (default-cli) @ msgpack-core <<<
[INFO]
[INFO] --- findbugs-maven-plugin:2.5.2:check (default-cli) @ msgpack-core ---
[INFO] BugInstance size is 1
[INFO] Error size is 0
[INFO] Total bugs: 1
[INFO] Dead store to off in org.msgpack.core.MessageBuffer.toByteArray() ["org.msgpack.core.MessageBuffer"] At MessageBuffer.java:[lines 154-734]
```

```
$ mvn site
     :
$ open msgpack-core/target/site/findbugs.html
```
