### PR TITLE
Look up MesageFormat[256] table to improve the unpack performance

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageFormat.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageFormat.java
@@ -309,17 +309,17 @@ public enum MessageFormat {
      */
     abstract int skip(MessageUnpacker unpacker) throws IOException;
 
-    private final static MessageFormat[] formatTable = MessageFormat.values();
-    private final static byte[] table = new byte[256];
+    private final static MessageFormat[] formatTable = new MessageFormat[256];
 
     static {
-        for(int b = 0; b < 0xFF; ++b) {
-            table[b] = (byte) toMessageFormat((byte) b).ordinal();
+        for(int b = 0; b <= 0xFF; ++b) {
+            MessageFormat mf = toMessageFormat((byte) b);
+            formatTable[b] = mf;
         }
     }
 
     public static MessageFormat valueOf(final byte b) {
-        return formatTable[table[b & 0xFF]];
+        return formatTable[b & 0xFF];
     }
 
 

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessageFormatTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessageFormatTest.scala
@@ -84,7 +84,7 @@ class MessageFormatTest extends MessagePackSpec {
       check(Code.ARRAY16, ValueType.ARRAY, MessageFormat.ARRAY16)
       check(Code.ARRAY32, ValueType.ARRAY, MessageFormat.ARRAY32)
 
-      for(i <- 0xe0 until 0xff)
+      for(i <- 0xe0 to 0xff)
         check(i.toByte, ValueType.INTEGER, MessageFormat.NEGFIXINT)
 
     }


### PR DESCRIPTION
I measured the performance difference of byte code to MessageFormat conversion between using switch-case statements, `MesageFormat.values()[byte[256]]` (one-indirection) and `MessageFormat[256]` (no indirection) look-up table. The last one is the orders of magnitude faster than the other methods, so I modified the code to create MessageFormat[256] for looking up MessageFormat types.

![performance comparison](https://www.evernote.com/shard/s18/sh/d92f0f3b-a5eb-444a-8d57-19d928660dc0/3323e41bb6c9957d04557842fe17ee29/deep/0/2.-leo@weaver.local---work-git-msgpack-java-%28java%29.png)
