### PR TITLE
readPayloadAsReference

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -202,6 +202,9 @@ public class MessageUnpacker implements Closeable {
      * @throws IOException
      */
     private boolean ensure(int byteSizeToRead) throws IOException {
+        if(byteSizeToRead == 0)
+            return true;
+
         if(!ensureBuffer())
             return false;
 
@@ -1014,6 +1017,16 @@ public class MessageUnpacker implements Closeable {
             consume(l);
             writtenLen += l;
         }
+    }
+
+    public MessageBuffer readPayloadAsReference(int length) throws IOException {
+        checkArgument(length >= 0);
+        if(!ensure(length))
+            throw new EOFException();
+
+        MessageBuffer ref = buffer.slice(position, length);
+        position += length;
+        return ref;
     }
 
 


### PR DESCRIPTION
Implemented #105 (returning a reference to the message buffer). Currently it simply returns a slice of MessageBuffer to the user. `readPayloadAsReference` is orders of magnitude faster than `readPayload(byte[])` since it can avoid the cost of buffer allocation and memory copy: 

![1__leo_weaver_local___work_git_msgpack-java__zsh_](https://cloud.githubusercontent.com/assets/57538/3226967/72d315cc-f075-11e3-8ab9-f0f3edb0a7a6.png)

Future work:
- To manage the total amount of the allocated memory, MessageUnpacker should have a buffer allocator.
