### PR TITLE
Fix NPE when properties of bean are manually indexed

### DIFF
--- a/src/main/java/org/msgpack/template/builder/ReflectionBeansTemplateBuilder.java
+++ b/src/main/java/org/msgpack/template/builder/ReflectionBeansTemplateBuilder.java
@@ -131,7 +131,7 @@ public class ReflectionBeansTemplateBuilder extends ReflectionTemplateBuilder {
                     throw new TemplateBuildException("invalid index: " + index);
                 }
                 entries[index] = new BeansFieldEntry(p);
-                props[index] = null;
+                props[i] = null;
             }
         }
         int insertIndex = 0;

--- a/src/test/java/org/msgpack/TestMessagePack02.java
+++ b/src/test/java/org/msgpack/TestMessagePack02.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayOutputStream;
 import org.junit.Test;
 import org.msgpack.testclasses.EnumTypeFieldsClass;
 import org.msgpack.testclasses.EnumTypeFieldsClassNotNullable;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.ListTypeFieldsClass;
@@ -2551,6 +2553,234 @@ public class TestMessagePack02 {
 	    MessagePack msgpack = new MessagePack();
 	    Value value = msgpack.unconvert(v);
 	    ReferenceCycleTypeFieldsClassNotNullable ret = msgpack.convert(value, ReferenceCycleTypeFieldsClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassBufferPackBufferUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    byte[] bytes = msgpack.write(v);
+	    IndexedFieldsBeanClass ret = msgpack.read(bytes, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassBufferPackConvert extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    byte[] bytes = msgpack.write(v);
+	    Value value = msgpack.read(bytes);
+	    IndexedFieldsBeanClass ret = msgpack.convert(value, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassBufferPackUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    byte[] bytes = msgpack.write(v);
+	    ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+	    IndexedFieldsBeanClass ret = msgpack.read(in, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassPackBufferUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    ByteArrayOutputStream out = new ByteArrayOutputStream();
+	    msgpack.write(out, v);
+	    byte[] bytes = out.toByteArray();
+	    IndexedFieldsBeanClass ret = msgpack.read(bytes, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassPackConvert extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    ByteArrayOutputStream out = new ByteArrayOutputStream();
+	    msgpack.write(out, v);
+	    byte[] bytes = out.toByteArray();
+	    Value value = msgpack.read(bytes);
+	    IndexedFieldsBeanClass ret = msgpack.convert(value, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassPackUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    ByteArrayOutputStream out = new ByteArrayOutputStream();
+	    msgpack.write(out, v);
+	    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+	    IndexedFieldsBeanClass ret = msgpack.read(in, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassUnconvertConvert extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClass() throws Exception {
+	    super.testIndexedFieldsBeanClass();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    Value value = msgpack.unconvert(v);
+	    IndexedFieldsBeanClass ret = msgpack.convert(value, IndexedFieldsBeanClass.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullableBufferPackBufferUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    byte[] bytes = msgpack.write(v);
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.read(bytes, IndexedFieldsBeanClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullableBufferPackConvert extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    byte[] bytes = msgpack.write(v);
+	    Value value = msgpack.read(bytes);
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.convert(value, IndexedFieldsBeanClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullableBufferPackUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    byte[] bytes = msgpack.write(v);
+	    ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.read(in, IndexedFieldsBeanClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullablePackBufferUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    ByteArrayOutputStream out = new ByteArrayOutputStream();
+	    msgpack.write(out, v);
+	    byte[] bytes = out.toByteArray();
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.read(bytes, IndexedFieldsBeanClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullablePackConvert extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    ByteArrayOutputStream out = new ByteArrayOutputStream();
+	    msgpack.write(out, v);
+	    byte[] bytes = out.toByteArray();
+	    Value value = msgpack.read(bytes);
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.convert(value, IndexedFieldsBeanClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullablePackUnpack extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    ByteArrayOutputStream out = new ByteArrayOutputStream();
+	    msgpack.write(out, v);
+	    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.read(in, IndexedFieldsBeanClassNotNullable.class);
+	    assertEquals(v, ret);
+	}
+    }
+
+    public static class TestIndexedFieldsBeanClassNotNullableUnconvertConvert extends org.msgpack.template.builder.TestSet {
+	@Test @Override
+	public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	    super.testIndexedFieldsBeanClassNotNullable();
+	}
+
+	@Override
+	public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	    MessagePack msgpack = new MessagePack();
+	    Value value = msgpack.unconvert(v);
+	    IndexedFieldsBeanClassNotNullable ret = msgpack.convert(value, IndexedFieldsBeanClassNotNullable.class);
 	    assertEquals(v, ret);
 	}
     }

--- a/src/test/java/org/msgpack/template/builder/TestReflectionBeansBufferPackBufferUnpack.java
+++ b/src/test/java/org/msgpack/template/builder/TestReflectionBeansBufferPackBufferUnpack.java
@@ -11,6 +11,8 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.Template;
 import org.msgpack.testclasses.AbstractClass;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.Interface;
@@ -386,6 +388,99 @@ public class TestReflectionBeansBufferPackBufferUnpack extends TestSet {
 	unpacker.wrap(bytes);
 	ReferenceCycleTypeFieldsClassNotNullable ret = tmpl.read(unpacker, null);
 	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClass() throws Exception {
+	super.testIndexedFieldsBeanClass();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+	IndexedFieldsBeanClass ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassFieldsUnpackedInOrder(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	super.testIndexedFieldsBeanClassNotNullable();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+	IndexedFieldsBeanClassNotNullable ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullableFieldsUnpackedInOrder(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
 	assertEquals(bytes.length, unpacker.getReadByteCount());
     }
 

--- a/src/test/java/org/msgpack/template/builder/TestReflectionBeansBufferPackConvert.java
+++ b/src/test/java/org/msgpack/template/builder/TestReflectionBeansBufferPackConvert.java
@@ -11,6 +11,8 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.Template;
 import org.msgpack.testclasses.AbstractClass;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.Interface;
@@ -417,6 +419,54 @@ public class TestReflectionBeansBufferPackConvert extends TestSet {
 	Value value = u.readValue();
 	Converter unpacker = new Converter(value);
 	ReferenceCycleTypeFieldsClassNotNullable ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, u.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClass() throws Exception {
+	super.testIndexedFieldsBeanClass();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	BufferUnpacker u = msgpack.createBufferUnpacker();
+	u.resetReadByteCount();
+	u.wrap(bytes);
+	Value value = u.readValue();
+	Converter unpacker = new Converter(value);
+	IndexedFieldsBeanClass ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, u.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	super.testIndexedFieldsBeanClassNotNullable();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	BufferUnpacker u = msgpack.createBufferUnpacker();
+	u.resetReadByteCount();
+	u.wrap(bytes);
+	Value value = u.readValue();
+	Converter unpacker = new Converter(value);
+	IndexedFieldsBeanClassNotNullable ret = tmpl.read(unpacker, null);
 	assertEquals(v, ret);
 	assertEquals(bytes.length, u.getReadByteCount());
     }

--- a/src/test/java/org/msgpack/template/builder/TestReflectionBeansBufferPackUnpack.java
+++ b/src/test/java/org/msgpack/template/builder/TestReflectionBeansBufferPackUnpack.java
@@ -13,6 +13,8 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.Template;
 import org.msgpack.testclasses.AbstractClass;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.Interface;
@@ -373,6 +375,94 @@ public class TestReflectionBeansBufferPackUnpack extends TestSet {
 	unpacker.resetReadByteCount();
 	ReferenceCycleTypeFieldsClassNotNullable ret = tmpl.read(unpacker, null);
 	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClass() throws Exception {
+	super.testIndexedFieldsBeanClass();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+	IndexedFieldsBeanClass ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassFieldsUnpackedInOrder(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	super.testIndexedFieldsBeanClassNotNullable();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+	IndexedFieldsBeanClassNotNullable ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullableFieldsUnpackedInOrder(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	BufferPacker packer = msgpack.createBufferPacker();
+	tmpl.write(packer, v);
+	byte[] bytes = packer.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
 	assertEquals(bytes.length, unpacker.getReadByteCount());
     }
 

--- a/src/test/java/org/msgpack/template/builder/TestReflectionBeansPackBufferUnpack.java
+++ b/src/test/java/org/msgpack/template/builder/TestReflectionBeansPackBufferUnpack.java
@@ -13,6 +13,8 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.Template;
 import org.msgpack.testclasses.AbstractClass;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.Interface;
@@ -403,6 +405,102 @@ public class TestReflectionBeansPackBufferUnpack extends TestSet {
 	unpacker.wrap(bytes);
 	ReferenceCycleTypeFieldsClassNotNullable ret = tmpl.read(unpacker, null);
 	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClass() throws Exception {
+	super.testIndexedFieldsBeanClass();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+	IndexedFieldsBeanClass ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassFieldsUnpackedInOrder(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	super.testIndexedFieldsBeanClassNotNullable();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+	IndexedFieldsBeanClassNotNullable ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullableFieldsUnpackedInOrder(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	BufferUnpacker unpacker = msgpack.createBufferUnpacker();
+	unpacker.resetReadByteCount();
+	unpacker.wrap(bytes);
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
 	assertEquals(bytes.length, unpacker.getReadByteCount());
     }
 

--- a/src/test/java/org/msgpack/template/builder/TestReflectionBeansPackConvert.java
+++ b/src/test/java/org/msgpack/template/builder/TestReflectionBeansPackConvert.java
@@ -13,6 +13,8 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.Template;
 import org.msgpack.testclasses.AbstractClass;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.Interface;
@@ -434,6 +436,56 @@ public class TestReflectionBeansPackConvert extends TestSet {
 	Value value = u.readValue();
 	Converter unpacker = new Converter(value);
 	ReferenceCycleTypeFieldsClassNotNullable ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, u.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClass() throws Exception {
+	super.testIndexedFieldsBeanClass();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	BufferUnpacker u = msgpack.createBufferUnpacker();
+	u.resetReadByteCount();
+	u.wrap(bytes);
+	Value value = u.readValue();
+	Converter unpacker = new Converter(value);
+	IndexedFieldsBeanClass ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, u.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	super.testIndexedFieldsBeanClassNotNullable();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	BufferUnpacker u = msgpack.createBufferUnpacker();
+	u.resetReadByteCount();
+	u.wrap(bytes);
+	Value value = u.readValue();
+	Converter unpacker = new Converter(value);
+	IndexedFieldsBeanClassNotNullable ret = tmpl.read(unpacker, null);
 	assertEquals(v, ret);
 	assertEquals(bytes.length, u.getReadByteCount());
     }

--- a/src/test/java/org/msgpack/template/builder/TestReflectionBeansPackUnpack.java
+++ b/src/test/java/org/msgpack/template/builder/TestReflectionBeansPackUnpack.java
@@ -14,6 +14,8 @@ import org.msgpack.template.TemplateRegistry;
 import org.msgpack.template.Template;
 import org.msgpack.testclasses.AbstractClass;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.Interface;
@@ -389,6 +391,98 @@ public class TestReflectionBeansPackUnpack extends TestSet {
 	unpacker.resetReadByteCount();
 	ReferenceCycleTypeFieldsClassNotNullable ret = tmpl.read(unpacker, null);
 	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClass() throws Exception {
+	super.testIndexedFieldsBeanClass();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+	IndexedFieldsBeanClass ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassFieldsUnpackedInOrder(IndexedFieldsBeanClass v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClass> tmpl = builder.buildTemplate(IndexedFieldsBeanClass.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Test @Override
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	super.testIndexedFieldsBeanClassNotNullable();
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+	IndexedFieldsBeanClassNotNullable ret = tmpl.read(unpacker, null);
+	assertEquals(v, ret);
+	assertEquals(bytes.length, unpacker.getReadByteCount());
+    }
+
+    @Override
+    public void testIndexedFieldsBeanClassNotNullableFieldsUnpackedInOrder(IndexedFieldsBeanClassNotNullable v) throws Exception {
+	MessagePack msgpack = new MessagePack();
+	TemplateRegistry registry = new TemplateRegistry(null);
+	ReflectionBeansTemplateBuilder builder = new ReflectionBeansTemplateBuilder(registry);
+	Template<IndexedFieldsBeanClassNotNullable> tmpl = builder.buildTemplate(IndexedFieldsBeanClassNotNullable.class);
+	ByteArrayOutputStream out = new ByteArrayOutputStream();
+	Packer packer = msgpack.createPacker(out);
+	tmpl.write(packer, v);
+	byte[] bytes = out.toByteArray();
+	Unpacker unpacker = msgpack.createUnpacker(new ByteArrayInputStream(bytes));
+	unpacker.resetReadByteCount();
+
+	unpacker.readArrayBegin();
+	assertEquals("alpha", unpacker.readString());
+	assertEquals("bravo", unpacker.readString());
+	assertEquals("charlie", unpacker.readString());
+	assertEquals("delta", unpacker.readString());
+	assertEquals("echo", unpacker.readString());
+	unpacker.readArrayEnd();
+
 	assertEquals(bytes.length, unpacker.getReadByteCount());
     }
 

--- a/src/test/java/org/msgpack/template/builder/TestSet.java
+++ b/src/test/java/org/msgpack/template/builder/TestSet.java
@@ -12,6 +12,8 @@ import org.msgpack.MessageTypeException;
 import org.msgpack.testclasses.EnumTypeFieldsClass;
 import org.msgpack.testclasses.EnumTypeFieldsClassNotNullable;
 import org.msgpack.testclasses.FinalClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClass;
+import org.msgpack.testclasses.IndexedFieldsBeanClassNotNullable;
 import org.msgpack.testclasses.InheritanceClass;
 import org.msgpack.testclasses.InheritanceClassNotNullable;
 import org.msgpack.testclasses.ListTypeFieldsClass;
@@ -432,6 +434,50 @@ public class TestSet {
     }
 
     public void testReferenceCycleTypeFieldsClassNotNullable(ReferenceCycleTypeFieldsClassNotNullable v) throws Exception {
+    }
+
+    public void testIndexedFieldsBeanClass() throws Exception {
+	testIndexedFieldsBeanClass(null);
+	testIndexedFieldsBeanClass(new IndexedFieldsBeanClass());
+	IndexedFieldsBeanClass v = new IndexedFieldsBeanClass();
+	v.f5 = "alpha";
+	v.f4 = "echo";
+	v.f3 = "bravo";
+	v.f2 = "delta";
+	v.f1 = "charlie";
+	testIndexedFieldsBeanClass(v);
+	testIndexedFieldsBeanClassFieldsUnpackedInOrder(v);
+    }
+
+    public void testIndexedFieldsBeanClass(IndexedFieldsBeanClass v) throws Exception {
+    }
+
+    public void testIndexedFieldsBeanClassFieldsUnpackedInOrder(IndexedFieldsBeanClass v) throws Exception {
+    }
+
+    public void testIndexedFieldsBeanClassNotNullable() throws Exception {
+	testIndexedFieldsBeanClassNotNullable(null);
+	try {
+	    testIndexedFieldsBeanClassNotNullable(new IndexedFieldsBeanClassNotNullable());
+	    Assert.fail();
+	} catch (Throwable t) {
+	    Assert.assertTrue(t instanceof MessageTypeException);
+	}
+
+	IndexedFieldsBeanClassNotNullable v = new IndexedFieldsBeanClassNotNullable();
+	v.f5 = "alpha";
+	v.f4 = "echo";
+	v.f3 = "bravo";
+	v.f2 = "delta";
+	v.f1 = "charlie";
+	testIndexedFieldsBeanClassNotNullable(v);
+	testIndexedFieldsBeanClassNotNullableFieldsUnpackedInOrder(v);
+    }
+
+    public void testIndexedFieldsBeanClassNotNullable(IndexedFieldsBeanClassNotNullable v) throws Exception {
+    }
+
+    public void testIndexedFieldsBeanClassNotNullableFieldsUnpackedInOrder(IndexedFieldsBeanClassNotNullable v) throws Exception {
     }
 
     public void testInheritanceClass() throws Exception {

--- a/src/test/java/org/msgpack/testclasses/IndexedFieldsBeanClass.java
+++ b/src/test/java/org/msgpack/testclasses/IndexedFieldsBeanClass.java
@@ -1,0 +1,114 @@
+package org.msgpack.testclasses;
+
+import org.junit.Ignore;
+import org.msgpack.annotation.Index;
+import org.msgpack.annotation.MessagePackBeans;
+
+@Ignore @MessagePackBeans
+public class IndexedFieldsBeanClass {
+
+    public String f5;
+
+    public String f4;
+
+    public String f3;
+
+    public String f2;
+
+    public String f1;
+
+    @Index(0)
+    public String getF5() {
+        return f5;
+    }
+
+    public void setF5(String f5) {
+        this.f5 = f5;
+    }
+
+    @Index(4)
+    public String getF4() {
+        return f4;
+    }
+
+    public void setF4(String f4) {
+        this.f4 = f4;
+    }
+
+    public String getF3() {
+        return f3;
+    }
+
+    @Index(1)
+    public void setF3(String f3) {
+        this.f3 = f3;
+    }
+
+    public String getF2() {
+        return f2;
+    }
+
+    @Index(3)
+    public void setF2(String f2) {
+        this.f2 = f2;
+    }
+
+    @Index(2)
+    public String getF1() {
+        return f1;
+    }
+
+    public void setF1(String f1) {
+        this.f1 = f1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (! (o instanceof IndexedFieldsBeanClass)) {
+            return false;
+        }
+        IndexedFieldsBeanClass that = (IndexedFieldsBeanClass) o;
+        if (f5 == null) {
+            if (that.f5 != null) {
+                return false;
+            }
+        }
+        if (that.f5 != null && ! f5.equals(that.f5)) {
+            return false;
+        }
+        if (f4 == null) {
+            if (that.f4 != null) {
+                return false;
+            }
+        }
+        if (that.f4 != null && ! f4.equals(that.f4)) {
+            return false;
+        }
+        if (f3 == null) {
+            if (that.f3 != null) {
+                return false;
+            }
+        }
+        if (that.f3 != null && ! f3.equals(that.f3)) {
+            return false;
+        }
+        if (f2 == null) {
+            if (that.f2 != null) {
+                return false;
+            }
+        }
+        if (that.f2 != null && ! f2.equals(that.f2)) {
+            return false;
+        }
+        if (f1 == null) {
+            if (that.f1 != null) {
+                return false;
+            }
+        }
+        if (that.f1 != null && ! f1.equals(that.f1)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/test/java/org/msgpack/testclasses/IndexedFieldsBeanClassNotNullable.java
+++ b/src/test/java/org/msgpack/testclasses/IndexedFieldsBeanClassNotNullable.java
@@ -1,0 +1,118 @@
+package org.msgpack.testclasses;
+
+import org.junit.Ignore;
+import org.msgpack.annotation.*;
+
+@Ignore @MessagePackBeans
+public class IndexedFieldsBeanClassNotNullable {
+
+    public String f5;
+
+    public String f4;
+
+    public String f3;
+
+    public String f2;
+
+    public String f1;
+
+    @Index(0) @NotNullable
+    public String getF5() {
+        return f5;
+    }
+
+    @NotNullable
+    public void setF5(String f5) {
+        this.f5 = f5;
+    }
+
+    @Index(4) @NotNullable
+    public String getF4() {
+        return f4;
+    }
+
+    @NotNullable
+    public void setF4(String f4) {
+        this.f4 = f4;
+    }
+
+    @NotNullable
+    public String getF3() {
+        return f3;
+    }
+
+    @Index(1) @NotNullable
+    public void setF3(String f3) {
+        this.f3 = f3;
+    }
+
+    @NotNullable
+    public String getF2() {
+        return f2;
+    }
+
+    @Index(3) @NotNullable
+    public void setF2(String f2) {
+        this.f2 = f2;
+    }
+
+    @Index(2) @NotNullable
+    public String getF1() {
+        return f1;
+    }
+
+    @NotNullable
+    public void setF1(String f1) {
+        this.f1 = f1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (! (o instanceof IndexedFieldsBeanClassNotNullable)) {
+            return false;
+        }
+        IndexedFieldsBeanClassNotNullable that = (IndexedFieldsBeanClassNotNullable) o;
+        if (f5 == null) {
+            if (that.f5 != null) {
+                return false;
+            }
+        }
+        if (that.f5 != null && ! f5.equals(that.f5)) {
+            return false;
+        }
+        if (f4 == null) {
+            if (that.f4 != null) {
+                return false;
+            }
+        }
+        if (that.f4 != null && ! f4.equals(that.f4)) {
+            return false;
+        }
+        if (f3 == null) {
+            if (that.f3 != null) {
+                return false;
+            }
+        }
+        if (that.f3 != null && ! f3.equals(that.f3)) {
+            return false;
+        }
+        if (f2 == null) {
+            if (that.f2 != null) {
+                return false;
+            }
+        }
+        if (that.f2 != null && ! f2.equals(that.f2)) {
+            return false;
+        }
+        if (f1 == null) {
+            if (that.f1 != null) {
+                return false;
+            }
+        }
+        if (that.f1 != null && ! f1.equals(that.f1)) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
When bean's properties ordering has been annotated (@Index), NullPointerException
in ReflectionBeansTemplateBuilder#toFieldEntries(Class, FieldOption) will occur
if annotated order is different than introspected order.
