### PR TITLE
Fix assert() condition in MessageBufferOutput subclasses

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
@@ -19,7 +19,7 @@ public class ChannelBufferOutput implements MessageBufferOutput {
 
     @Override
     public void flush(MessageBuffer buf, int offset, int len) throws IOException {
-        assert(offset + len < buf.size());
+        assert(offset + len <= buf.size());
         ByteBuffer bb = buf.toByteBuffer(offset, len);
         channel.write(bb);
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/OutputStreamBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/OutputStreamBufferOutput.java
@@ -18,7 +18,7 @@ public class OutputStreamBufferOutput implements MessageBufferOutput {
 
     @Override
     public void flush(MessageBuffer buf, int offset, int len) throws IOException {
-        assert(offset + len < buf.size());
+        assert(offset + len <= buf.size());
 
         // TODO reuse the allocated buffer
         byte[] in = new byte[len];


### PR DESCRIPTION
The assert() in ChannelBufferOutput/OutputStreamBufferOutput#flush() looks to have a wrong condition. With `-ea` option on IntelliJ, org.msgpack.core.MessagePackTest("pack/unpack binary") failed.

For sbt, I tried to reproduce but I didn't find a proper way. The following change didn't work...

```
diff --git a/project/Build.scala b/project/Build.scala
index 21d221b..ce1aba9 100644
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -51,6 +51,7 @@ object Build extends Build {
       //resolvers += Resolver.mavenLocal,
       scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked", "-target:jvm-1.6", "-feature"),
       javacOptions in (Compile, compile) ++= Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-Xlint:deprecation", "-source", "1.6", "-target", "1.6"),
+      javaOptions ++= Seq("-ea"),
       pomExtra := {
         <url>http://msgpack.org/</url>
           <licenses>
```
