### PR TITLE
Avoid calling out.flush() in MessagePacker#reset() since it can be already closed

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -91,7 +91,8 @@ public class MessagePacker implements Closeable {
         // Validate the argument
         MessageBufferOutput newOut = checkNotNull(out, "MessageBufferOutput is null");
 
-        close(); // Flush and close
+        this.out.close();
+
         this.out = newOut;
         this.position = 0;
     }


### PR DESCRIPTION
@xerial When MessagePacker#reset() is called, its MessageBufferOutput instance `out` can be already closed in order to avoid a resource leak. So, it would go wrong if `out.flush()` is called in MessagePacker#reset().
