### PR TITLE
Add a benchmark of MessageBufferInput#reset

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ArrayBufferInput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ArrayBufferInput.java
@@ -20,14 +20,17 @@ public class ArrayBufferInput implements MessageBufferInput {
         this.buffer = MessageBuffer.wrap(checkNotNull(arr, "input array is null")).slice(offset, length);
     }
 
-    public void reset(byte[] arr) {
-        this.buffer = MessageBuffer.wrap(checkNotNull(arr, "input array is null"));
+    public void reset(MessageBuffer buf) {
+        this.buffer = buf;
         this.isRead = false;
     }
 
+    public void reset(byte[] arr) {
+        reset(MessageBuffer.wrap(checkNotNull(arr, "input array is null")));
+    }
+
     public void reset(byte[] arr, int offset, int len) {
-        this.buffer = MessageBuffer.wrap(checkNotNull(arr, "input array is null")).slice(offset, len);
-        this.isRead = false;
+        reset(MessageBuffer.wrap(checkNotNull(arr, "input array is null")).slice(offset, len));
     }
 
     @Override

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessageUnpackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessageUnpackerTest.scala
@@ -531,13 +531,14 @@ class MessageUnpackerTest extends MessagePackSpec {
     }
 
     // TODO: change tag 'ignore' to 'in'
-    "improve the performance via reset method" taggedAs("reset") ignore {
+    "improve the performance via reset method" taggedAs("reset-arr") in {
 
       val out = new ByteArrayOutputStream
       val packer = MessagePackFactory.newDefaultPacker(out)
       packer.packInt(0)
       packer.flush
       val arr = out.toByteArray
+      val mb = MessageBuffer.wrap(arr)
 
       val N = 1000
       val t = time("unpacker", repeat = 10) {
@@ -556,7 +557,7 @@ class MessageUnpackerTest extends MessagePackSpec {
           IOUtil.withResource(MessagePackFactory.newDefaultUnpacker(arr)) { unpacker =>
             val buf = new ArrayBufferInput(arr)
             for (i <- 0 until N) {
-              buf.reset(arr)
+              buf.reset(mb)
               unpacker.reset(buf)
               unpacker.unpackInt
               unpacker.close


### PR DESCRIPTION
@xerial I added a benchmark test of MessageBufferInput#reset (ArrayBufferInput#reset). But there is no difference between the results which using reset() or not. So I've disabled the test with `ignore` tag to avoid a test failure.

Can you see if there is room to improve the performance of reset() with this test? It seems that ArrayBufferInput#reset always recreates a new buffer and to reuse the buffer can improve the performance. Thanks.
