### PR TITLE
Set proper size for key-vaue array in MapCursorImpl.

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/value/impl/MapCursorImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/MapCursorImpl.java
@@ -109,7 +109,7 @@ public class MapCursorImpl extends AbstractValueRef implements MapCursor {
     @Override
     public MapValue toValue() {
         ensureNotTraversed();
-        Value[] keyValueArray = new Value[mapSize];
+        Value[] keyValueArray = new Value[mapSize * 2];
         int i = 0;
         while(hasNext()) {
             keyValueArray[i++] = nextKeyOrValue().toValue();

--- a/msgpack-core/src/test/scala/org/msgpack/value/CursorTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/CursorTest.scala
@@ -52,6 +52,24 @@ class CursorTest extends MessagePackSpec {
       }
     }
 
+    "have map cursor" taggedAs("map") in {
+      val packedData = createMessagePackData { packer =>
+        packer packMapHeader(1) packString("f") packString("x")
+      }
+
+      val cursor = mf.newUnpacker(packedData).getCursor
+      val mapCursor = cursor.nextRef().getMapCursor
+      mapCursor.size() shouldBe 1
+
+      val mapValue = mapCursor.toValue
+      val data = mapValue.toKeyValueSeq
+
+      data should have length 2
+
+      data(0).asString().toString shouldBe "f"
+      data(1).asString().toString shouldBe "x"
+    }
+
     "traverse ValueRef faster than traversing Value" taggedAs("ref") in {
       val N = 10000
       val data = binSeq(N)


### PR DESCRIPTION
This addresses the issue reported in #149, including both a specific unit test and a bigger functional test.

Apologies for my Scala - I'm not well-versed in the language.  Suggestions for improvement welcome.
