### PR TITLE
RawStringValueImpl#equals and #hashcode use the same logics with StringV...

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/value/impl/RawStringValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/RawStringValueImpl.java
@@ -1,6 +1,7 @@
 package org.msgpack.value.impl;
 
 import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageStringCodingException;
 import org.msgpack.value.ValueType;
 import org.msgpack.value.*;
 
@@ -54,12 +55,16 @@ public class RawStringValueImpl extends RawValueImpl implements StringValue {
         if (!v.isString()) {
             return false;
         }
-        StringValue sv = v.asString();
-        return sv.toByteBuffer().equals(byteBuffer);
+        try {
+            return toString().equals(v.asString().toString());
+        } catch (MessageStringCodingException ex) {
+            return false;
+        }
+
     }
 
     @Override
     public int hashCode() {
-        return byteBuffer.hashCode();
+        return toString().hashCode();
     }
 }

--- a/msgpack-core/src/test/scala/org/msgpack/value/RawStringValueImplTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/RawStringValueImplTest.scala
@@ -2,9 +2,6 @@ package org.msgpack.value
 
 import org.msgpack.core.MessagePackSpec
 
-/**
- * Created on 6/13/14.
- */
 class RawStringValueImplTest extends MessagePackSpec {
 
   "StringValue" should {

--- a/msgpack-core/src/test/scala/org/msgpack/value/RawStringValueImplTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/RawStringValueImplTest.scala
@@ -1,0 +1,22 @@
+package org.msgpack.value
+
+import org.msgpack.core.MessagePackSpec
+
+/**
+ * Created on 6/13/14.
+ */
+class RawStringValueImplTest extends MessagePackSpec {
+
+  "StringValue" should {
+    "return the same hash code if they are equal" in {
+      val str = "a"
+      val a1 = ValueFactory.newRawString(str.getBytes("UTF-8"))
+      val a2 = ValueFactory.newString(str)
+
+      a1.shouldEqual(a2)
+      a1.hashCode.shouldEqual(a2.hashCode)
+      a2.shouldEqual(a1)
+      a2.hashCode.shouldEqual(a1.hashCode)
+    }
+  }
+}

--- a/msgpack-core/src/test/scala/org/msgpack/value/ValueFactoryTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/ValueFactoryTest.scala
@@ -50,17 +50,4 @@ class ValueFactoryTest extends MessagePackSpec {
     }
 
   }
-
-  "StringValue" should {
-    "return the same hash code if they are equal" in {
-      val str = "a"
-      val a1 = ValueFactory.newRawString(str.getBytes("UTF-8"))
-      val a2 = ValueFactory.newString(str)
-
-      a1.shouldEqual(a2)
-      a1.hashCode.shouldEqual(a2.hashCode)
-      a2.shouldEqual(a1)
-      a2.hashCode.shouldEqual(a1.hashCode)
-    }
-  }
 }

--- a/msgpack-core/src/test/scala/org/msgpack/value/ValueFactoryTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/ValueFactoryTest.scala
@@ -50,4 +50,17 @@ class ValueFactoryTest extends MessagePackSpec {
     }
 
   }
+
+  "StringValue" should {
+    "return the same hash code if they are equal" in {
+      val str = "a"
+      val a1 = ValueFactory.newRawString(str.getBytes("UTF-8"))
+      val a2 = ValueFactory.newString(str)
+
+      a1.shouldEqual(a2)
+      a1.hashCode.shouldEqual(a2.hashCode)
+      a2.shouldEqual(a1)
+      a2.hashCode.shouldEqual(a1.hashCode)
+    }
+  }
 }


### PR DESCRIPTION
...alueImpl

I thinks RawStringValueImpl#equals and #hashcode should use the same logics as StringValueImpl. I saw the performance of StringValueImpl#equals is two times better than RawStringValueImpl's one. So I applied StringValueImpl's logics to RawStringValueImpl.