### PR TITLE
MessageBufferOutput#reset shouldn't close an output passed as a paramete...

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
@@ -19,6 +19,7 @@ public class ChannelBufferOutput implements MessageBufferOutput {
     }
 
     public void reset(WritableByteChannel channel) throws IOException {
+        this.channel.close();
         this.channel = channel;
     }
 

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
@@ -19,7 +19,6 @@ public class ChannelBufferOutput implements MessageBufferOutput {
     }
 
     public void reset(WritableByteChannel channel) throws IOException {
-        channel.close();
         this.channel = channel;
     }
 

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/OutputStreamBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/OutputStreamBufferOutput.java
@@ -19,7 +19,6 @@ public class OutputStreamBufferOutput implements MessageBufferOutput {
     }
 
     public void reset(OutputStream out) throws IOException {
-        out.close();
         this.out = out;
     }
 

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/OutputStreamBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/OutputStreamBufferOutput.java
@@ -19,6 +19,7 @@ public class OutputStreamBufferOutput implements MessageBufferOutput {
     }
 
     public void reset(OutputStream out) throws IOException {
+        this.out.close();
         this.out = out;
     }
 

--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferOutputTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferOutputTest.scala
@@ -6,7 +6,9 @@ import java.io._
 class MessageBufferOutputTest extends MessagePackSpec {
 
   def createTempFile = {
-    File.createTempFile("msgpackTest", "msgpack")
+    val f = File.createTempFile("msgpackTest", "msgpack")
+    f.deleteOnExit
+    f
   }
 
   def createTempFileWithOutputStream = {

--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferOutputTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferOutputTest.scala
@@ -1,0 +1,59 @@
+package org.msgpack.core.buffer
+
+import org.msgpack.core.MessagePackSpec
+import java.io._
+
+class MessageBufferOutputTest extends MessagePackSpec {
+
+  def createTempFile = {
+    File.createTempFile("msgpackTest", "msgpack")
+  }
+
+  def createTempFileWithOutputStream = {
+    val f = createTempFile
+    val out = new FileOutputStream(f)
+    (f, out)
+  }
+
+  def createTempFileWithChannel = {
+    val (f, out) = createTempFileWithOutputStream
+    val ch = out.getChannel
+    (f, ch)
+  }
+
+  def writeIntToBuf(buf:MessageBufferOutput) = {
+    val mb0 = buf.next(8)
+    mb0.putInt(0, 42)
+    buf.flush(mb0)
+    buf.close
+  }
+
+  "OutputStreamBufferOutput" should {
+    "reset buffer" in {
+      val (f0, out0) = createTempFileWithOutputStream
+      val buf = new OutputStreamBufferOutput(out0)
+      writeIntToBuf(buf)
+      f0.length.toInt should be > 0
+
+      val (f1, out1) = createTempFileWithOutputStream
+      buf.reset(out1)
+      writeIntToBuf(buf)
+      f1.length.toInt should be > 0
+    }
+  }
+
+  "ChannelBufferOutput" should {
+    "reset buffer" in {
+      val (f0, ch0) = createTempFileWithChannel
+      val buf = new ChannelBufferOutput(ch0)
+      writeIntToBuf(buf)
+      f0.length.toInt should be > 0
+
+      val (f1, ch1) = createTempFileWithChannel
+      buf.reset(ch1)
+      writeIntToBuf(buf)
+      f1.length.toInt should be > 0
+    }
+  }
+
+}


### PR DESCRIPTION
...r

(`ChannelBufferOutput`|`OutputStreamBufferOutput`)#reset close WritableByteChannel or OutputStream passed as a parameter. As a result, when outputting to a file, it causes a write error because the file is already closed.