### PR TITLE
Close the previous assigned input in MessageBufferInput#reset

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferInput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferInput.java
@@ -26,7 +26,7 @@ public class ChannelBufferInput implements MessageBufferInput {
     }
 
     public void reset(ReadableByteChannel channel) throws IOException {
-        channel.close();
+        this.channel.close();
         this.channel = channel;
         this.reachedEOF = false;
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/InputStreamBufferInput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/InputStreamBufferInput.java
@@ -33,7 +33,7 @@ public class InputStreamBufferInput implements MessageBufferInput {
     }
 
     public void reset(InputStream in) throws IOException {
-        in.close();
+        this.in.close();
         this.in = in;
         reachedEOF = false;
     }

--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferInputTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferInputTest.scala
@@ -1,11 +1,12 @@
 package org.msgpack.core.buffer
 
-import org.msgpack.core.MessagePackSpec
+import org.msgpack.core.{MessageUnpacker, MessagePack, MessagePackSpec}
 import java.io._
 import xerial.core.io.IOUtil
 import scala.util.Random
 import java.util.zip.{GZIPOutputStream, GZIPInputStream}
 import java.nio.ByteBuffer
+import org.msgpack.unpacker.MessagePackUnpacker
 
 /**
  * Created on 5/30/14.
@@ -98,4 +99,54 @@ class MessageBufferInputTest extends MessagePackSpec {
     }
 
   }
+
+  def createTempFile = {
+    val f = File.createTempFile("msgpackTest", "msgpack")
+    f.deleteOnExit
+    f
+  }
+
+  def createTempFileWithInputStream = {
+    val f = createTempFile
+    val out = new FileOutputStream(f)
+    new MessagePack().newPacker(out).packInt(42).close
+    val in = new FileInputStream(f)
+    (f, in)
+  }
+
+  def createTempFileWithChannel = {
+    val (f, in) = createTempFileWithInputStream
+    val ch = in.getChannel
+    (f, ch)
+  }
+
+  def readInt(buf:MessageBufferInput) : Int = {
+    val unpacker = new MessageUnpacker(buf)
+    unpacker.unpackInt
+  }
+
+  "InputStreamBufferInput" should {
+    "reset buffer" in {
+      val (f0, in0) = createTempFileWithInputStream
+      val buf = new InputStreamBufferInput(in0)
+      readInt(buf) shouldBe 42
+
+      val (f1, in1) = createTempFileWithInputStream
+      buf.reset(in1)
+      readInt(buf) shouldBe 42
+    }
+  }
+
+  "ChannelBufferInput" should {
+    "reset buffer" in {
+      val (f0, in0) = createTempFileWithChannel
+      val buf = new ChannelBufferInput(in0)
+      readInt(buf) shouldBe 42
+
+      val (f1, in1) = createTempFileWithChannel
+      buf.reset(in1)
+      readInt(buf) shouldBe 42
+    }
+  }
+
 }


### PR DESCRIPTION
I found reset() in both `ChannelBufferInput` and `InputStreamBufferInput` close the previous assigned input. I fixed this issue as well as https://github.com/msgpack/msgpack-java/pull/169.

@xerial Can you review this PR too?