### PR TITLE
Set "-Xdoclint:none" only when the Java is 1.8 or more

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,16 @@ object Build extends Build {
       scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked", "-target:jvm-1.6", "-feature"),
       javaOptions in Test ++= Seq("-ea"),
       javacOptions in (Compile, compile) ++= Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-Xlint:deprecation", "-source", "1.6", "-target", "1.6"),
-      javacOptions in doc := Seq("-source", "1.6", "-Xdoclint:none"),
+      javacOptions in doc := {
+        val opts = Seq("-source", "1.6")
+        val (major, minor) = System.getProperty("java.version").split('.') match {
+          case Array(major, minor, _) => (major.toInt, minor.toInt)
+        }
+        if ((major == 1 && minor >= 8) || (major > 1))
+          opts ++ Seq("-Xdoclint:none")
+        else
+          opts
+      },
       findbugsReportType := Some(ReportType.FancyHtml),
       findbugsReportPath := Some(crossTarget.value / "findbugs" / "report.html"),
       pomExtra := {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -22,7 +22,8 @@ import de.johoop.findbugs4sbt.FindBugs._
 import de.johoop.jacoco4sbt._
 import JacocoPlugin._
 import sbtrelease.ReleasePlugin._
-import xerial.sbt.Sonatype._
+import scala.util.Properties
+
 
 object Build extends Build {
 
@@ -61,10 +62,7 @@ object Build extends Build {
       javacOptions in (Compile, compile) ++= Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-Xlint:deprecation", "-source", "1.6", "-target", "1.6"),
       javacOptions in doc := {
         val opts = Seq("-source", "1.6")
-        val (major, minor) = System.getProperty("java.version").split('.') match {
-          case Array(major, minor, _) => (major.toInt, minor.toInt)
-        }
-        if ((major == 1 && minor >= 8) || (major > 1))
+        if (Properties.isJavaAtLeast("1.8"))
           opts ++ Seq("-Xdoclint:none")
         else
           opts


### PR DESCRIPTION
When executing "publishLocal" on sbt, it failed with an error message `[error] javadoc: error - invalid flag: -Xdoclint:none`. I guess the reason why it failed is javadoc doesn't has the option in Java1.7 or before. If all the msgpack-java developers use Java1.8, we have nothing to do to fix this issue. But I don't think the limitation is so good. I fixed this issue but I'm not sure if this change is the best.

@xerial Can you review this PR?