### PR TITLE
Universal MessageBuffer implementation for supporting Java 6

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -41,9 +41,14 @@ public class MessageBuffer {
                 isJavaAtLeast7 = false;
             }
             else {
-                int major = Integer.parseInt(javaVersion.substring(0, dotPos));
-                int minor = Integer.parseInt(javaVersion.substring(dotPos+1));
-                isJavaAtLeast7 = major > 1 || (major == 1 && minor >= 7);
+                try {
+                    int major = Integer.parseInt(javaVersion.substring(0, dotPos));
+                    int minor = Integer.parseInt(javaVersion.substring(dotPos + 1));
+                    isJavaAtLeast7 = major > 1 || (major == 1 && minor >= 7);
+                }
+                catch(NumberFormatException e) {
+                    e.printStackTrace(System.err);
+                }
             }
 
             // Fetch theUnsafe object for Orackle JDK and OpenJDK
@@ -105,6 +110,8 @@ public class MessageBuffer {
                     assert false;
             }
 
+            // We need to use reflection to find MessageBuffer implementation classes because
+            // importing these classes creates TypeProfile and adds some overhead to method calls.
             String bufferClsName;
             if(isJavaAtLeast7) {
                 if(isLittleEndian)

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -30,13 +30,13 @@ public class MessageBuffer {
     static final boolean isByteBufferConstructorTakesBufferReference;
     static final int ARRAY_BYTE_BASE_OFFSET;
     static final int ARRAY_BYTE_INDEX_SCALE;
-    static final boolean isJavaAtLeast7;
 
     static {
         try {
             // Check java version
             String javaVersion = System.getProperty("java.specification.version", "");
             int dotPos = javaVersion.indexOf('.');
+            boolean isJavaAtLeast7 = false;
             if(dotPos == -1) {
                 isJavaAtLeast7 = false;
             }
@@ -357,7 +357,7 @@ public class MessageBuffer {
     }
 
     public void getBytes(int index, byte[] dst, int dstOffset, int length) {
-        unsafe.copyMemory(base, address+index, dst, ARRAY_BYTE_BASE_OFFSET + dstOffset, length);
+        unsafe.copyMemory(base, address + index, dst, ARRAY_BYTE_BASE_OFFSET + dstOffset, length);
     }
 
     public void getBytes(int index, int len, ByteBuffer dst) {

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
@@ -33,11 +33,15 @@ public class MessageBufferU extends MessageBuffer {
         }
     }
 
+    private void resetBufferPosition() {
+        reference.position(0);
+        reference.limit(size);
+    }
+
     @Override
     public byte getByte(int index) {
         return reference.get(index);
     }
-
     @Override
     public boolean getBoolean(int index) {
         return reference.get(index) != 0;
@@ -66,7 +70,12 @@ public class MessageBufferU extends MessageBuffer {
     public void getBytes(int index, int len, ByteBuffer dst) {
         reference.position(index);
         reference.limit(index+len);
-        dst.put(reference);
+        try {
+            dst.put(reference);
+        }
+        finally {
+            resetBufferPosition();
+        }
     }
     @Override
     public void putByte(int index, byte v) {
@@ -98,9 +107,14 @@ public class MessageBufferU extends MessageBuffer {
     }
     @Override
     public ByteBuffer toByteBuffer(int index, int length) {
-        reference.position(index);
-        reference.limit(index+length);
-        return reference.slice();
+        try {
+            reference.position(index);
+            reference.limit(index+length);
+            return reference.slice();
+        }
+        finally {
+            resetBufferPosition();
+        }
     }
     @Override
     public ByteBuffer toByteBuffer() {
@@ -109,8 +123,13 @@ public class MessageBufferU extends MessageBuffer {
 
     @Override
     public void getBytes(int index, byte[] dst, int dstOffset, int length) {
-        reference.position(index);
-        reference.get(dst, dstOffset, length);
+        try {
+            reference.position(index);
+            reference.get(dst, dstOffset, length);
+        }
+        finally {
+            resetBufferPosition();
+        }
     }
 
     @Override
@@ -132,7 +151,12 @@ public class MessageBufferU extends MessageBuffer {
     @Override
     public void putBytes(int index, byte[] src, int srcOffset, int length) {
         reference.position(index);
-        reference.put(src, srcOffset, length);
+        try {
+            reference.put(src, srcOffset, length);
+        }
+        finally {
+            resetBufferPosition();
+        }
     }
 
     @Override

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
@@ -75,7 +75,7 @@ public class MessageBufferU extends MessageBuffer {
     public void getBytes(int index, int len, ByteBuffer dst) {
         try {
             reference.position(index);
-            reference.limit(index+len);
+            reference.limit(index + len);
             dst.put(reference);
         }
         finally {
@@ -114,7 +114,7 @@ public class MessageBufferU extends MessageBuffer {
     public ByteBuffer toByteBuffer(int index, int length) {
         try {
             reference.position(index);
-            reference.limit(index+length);
+            reference.limit(index + length);
             return reference.slice();
         }
         finally {
@@ -142,15 +142,19 @@ public class MessageBufferU extends MessageBuffer {
         assert (len <= src.remaining());
 
         if(src.hasArray()) {
-            byte[] srcArray = src.array();
-            putBytes(index, srcArray, src.position(), len);
-
-        } else {
-            for(int i = 0; i < len; ++i) {
-                putByte(index + i, src.get());
+            putBytes(index, src.array(), src.position(), len);
+            src.position(src.position() + len);
+        }
+        else {
+            int prevSrcLimit = src.limit();
+            try {
+                src.limit(src.position() + len);
+                reference.put(src);
+            }
+            finally {
+                src.limit(prevSrcLimit);
             }
         }
-        src.position(src.position() + len);
     }
 
     @Override

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
@@ -1,0 +1,148 @@
+package org.msgpack.core.buffer;
+
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.msgpack.core.Preconditions.*;
+
+/**
+ * Universal MessageBuffer implementation supporting Java6 and Android.
+ * This buffer always uses ByteBuffer-based memory access
+ */
+public class MessageBufferU extends MessageBuffer {
+
+    MessageBufferU(ByteBuffer bb) {
+        super(null, 0L, bb.remaining(), bb.order(ByteOrder.BIG_ENDIAN));
+        checkNotNull(reference);
+    }
+
+    @Override
+    public MessageBufferU slice(int offset, int length) {
+        if(offset == 0 && length == size())
+            return this;
+        else {
+            checkArgument(offset + length <= size());
+            reference.position(offset);
+            reference.limit(offset + length);
+            return new MessageBufferU(reference.slice());
+        }
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return reference.get(index);
+    }
+
+    @Override
+    public boolean getBoolean(int index) {
+        return reference.get(index) != 0;
+    }
+    @Override
+    public short getShort(int index) {
+        return reference.getShort(index);
+    }
+    @Override
+    public int getInt(int index) {
+        return reference.getInt(index);
+    }
+    @Override
+    public float getFloat(int index) {
+        return reference.getFloat(index);
+    }
+    @Override
+    public long getLong(int index) {
+        return reference.getLong(index);
+    }
+    @Override
+    public double getDouble(int index) {
+        return reference.getDouble(index);
+    }
+    @Override
+    public void getBytes(int index, int len, ByteBuffer dst) {
+        reference.position(index);
+        reference.limit(index+len);
+        dst.put(reference);
+    }
+    @Override
+    public void putByte(int index, byte v) {
+        reference.put(index, v);
+    }
+    @Override
+    public void putBoolean(int index, boolean v) {
+        reference.put(index, v ? (byte) 1 : (byte) 0);
+    }
+    @Override
+    public void putShort(int index, short v) {
+        reference.putShort(index, v);
+    }
+    @Override
+    public void putInt(int index, int v) {
+        reference.putInt(index, v);
+    }
+    @Override
+    public void putFloat(int index, float v) {
+        reference.putFloat(index, v);
+    }
+    @Override
+    public void putLong(int index, long l) {
+        reference.putLong(index, l);
+    }
+    @Override
+    public void putDouble(int index, double v) {
+        reference.putDouble(index, v);
+    }
+    @Override
+    public ByteBuffer toByteBuffer(int index, int length) {
+        reference.position(index);
+        reference.limit(index+length);
+        return reference.slice();
+    }
+    @Override
+    public ByteBuffer toByteBuffer() {
+        return toByteBuffer(0, size);
+    }
+
+    @Override
+    public void getBytes(int index, byte[] dst, int dstOffset, int length) {
+        reference.position(index);
+        reference.get(dst, dstOffset, length);
+    }
+
+    @Override
+    public void putByteBuffer(int index, ByteBuffer src, int len) {
+        assert (len <= src.remaining());
+
+        if(src.hasArray()) {
+            byte[] srcArray = src.array();
+            putBytes(index, srcArray, src.position(), len);
+
+        } else {
+            for(int i = 0; i < len; ++i) {
+                putByte(index + i, src.get());
+            }
+        }
+        src.position(src.position() + len);
+    }
+
+    @Override
+    public void putBytes(int index, byte[] src, int srcOffset, int length) {
+        reference.position(index);
+        reference.put(src, srcOffset, length);
+    }
+
+    @Override
+    public void copyTo(int index, MessageBuffer dst, int offset, int length) {
+        if(dst.hasArray()) {
+            System.arraycopy(this.base, this.offset() + index, dst.getBase(), offset, length);
+        } else {
+            dst.putBytes(offset, this.getArray(), this.offset(), length);
+        }
+    }
+    @Override
+    public byte[] toByteArray() {
+        byte[] b = new byte[size()];
+        getBytes(0, b, 0, b.length);
+        return b;
+    }
+}

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
@@ -17,6 +17,10 @@ public class MessageBufferU extends MessageBuffer {
         checkNotNull(reference);
     }
 
+    MessageBufferU(byte[] arr) {
+        this(ByteBuffer.wrap(arr));
+    }
+
     @Override
     public MessageBufferU slice(int offset, int length) {
         if(offset == 0 && length == size())


### PR DESCRIPTION
Some JDK in 1.6.x (and Android) does not have `unsafe.copyMemory(srcObj, srcOffset, dstObj, dstOffset, len)` method, which resolves the object memory address inside JVM, so we cannot replace this method without using JNI.

To fix this problem, I added an universal MessageBuffer implementation (MessageBufferU). This fixes #160.