### PR TITLE
Add the constructors of DirectByteBuffer for old Android

### DIFF
--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala
@@ -112,6 +112,18 @@ class MessageBufferTest extends MessagePackSpec {
 
     }
 
+    "convert to ByteBuffer" in {
+      for (t <- Seq(
+        MessageBuffer.newBuffer(10),
+        MessageBuffer.newDirectBuffer(10),
+        MessageBuffer.newOffHeapBuffer(10))
+      ) {
+        val bb = t.toByteBuffer
+        bb.position shouldBe 0
+        bb.limit shouldBe 10
+        bb.capacity shouldBe 10
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Fix https://github.com/msgpack/msgpack-java/issues/189. It works on Android4.0.4. I guess this version uses https://android.googlesource.com/platform/libcore/+/bdd17cde8cf675f5d5703aad4dfb565932fb4c50/luni/src/main/java/java/nio/DirectByteBuffer.java.