### PR TITLE
Make MessagePacker internal state protected so it can be extended

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -55,15 +55,15 @@ public class MessagePacker implements Closeable {
     private final MessagePack.Config config;
 
     private MessageBufferOutput out;
-    private MessageBuffer buffer;
-    private MessageBuffer strLenBuffer;
+    protected MessageBuffer buffer;
+    protected MessageBuffer strLenBuffer;
 
-    private int position;
+    protected int position;
 
     /**
      * String encoder
      */
-    private CharsetEncoder encoder;
+    protected CharsetEncoder encoder;
 
 
     /**


### PR DESCRIPTION
Because MessagePacker internal state is private, there's no way to extend it.
This PR changes the visibility to protected. The other possibility would be to provide accessors for those.