### PR TITLE
Add MessagePacker.totalWrittenBytes

### DIFF
--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackerTest.scala
@@ -199,7 +199,23 @@ class MessagePackerTest extends MessagePackSpec {
       up1.hasNext shouldBe false
       up1.close
     }
-
   }
 
+  "compute totalWrittenBytes" in {
+    val out = new ByteArrayOutputStream
+    val packerTotalWrittenBytes = IOUtil.withResource(msgpack.newPacker(out)) { packer =>
+
+      packer.packByte(0)
+      .packBoolean(true)
+      .packShort(12)
+      .packInt(1024)
+      .packLong(Long.MaxValue)
+      .packString("foobar")
+      .flush()
+
+      packer.getTotalWritternBytes
+    }
+
+    out.toByteArray.length shouldBe packerTotalWrittenBytes
+  }
 }


### PR DESCRIPTION
This PR adds the ability to track the number of bytes a MessagePacker has packed.