### PR TITLE
Google App Engine Support

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
@@ -1,0 +1,140 @@
+package org.msgpack.core.buffer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * Wraps the difference of access methods to DirectBuffers between Android and others.
+ */
+class DirectBufferAccess {
+
+    enum DirectBufferConstructorType {
+        ARGS_LONG_INT_REF,
+        ARGS_LONG_INT,
+        ARGS_INT_INT,
+        ARGS_MB_INT_INT
+    }
+
+
+    static Method mGetAddress;
+    static Method mCleaner;
+    static Method mClean;
+
+    // TODO We should use MethodHandle for efficiency, but it is not available in JDK6
+    static Constructor byteBufferConstructor;
+    static Class<?> directByteBufferClass;
+    static DirectBufferConstructorType directBufferConstructorType;
+    static Method memoryBlockWrapFromJni;
+
+    static {
+        try {
+            // Find the hidden constructor for DirectByteBuffer
+            directByteBufferClass = ClassLoader.getSystemClassLoader().loadClass("java.nio.DirectByteBuffer");
+            Constructor directByteBufferConstructor = null;
+            DirectBufferConstructorType constructorType = null;
+            Method mbWrap = null;
+            try {
+                // TODO We should use MethodHandle for Java7, which can avoid the cost of boxing with JIT optimization
+                directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(long.class, int.class, Object.class);
+                constructorType = DirectBufferConstructorType.ARGS_LONG_INT_REF;
+            }
+            catch(NoSuchMethodException e0) {
+                try {
+                    // https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/java/nio/DirectByteBuffer.java
+                    // DirectByteBuffer(long address, int capacity)
+                    directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(long.class, int.class);
+                    constructorType = DirectBufferConstructorType.ARGS_LONG_INT;
+                }
+                catch(NoSuchMethodException e1) {
+                    try {
+                        directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(int.class, int.class);
+                        constructorType = DirectBufferConstructorType.ARGS_INT_INT;
+                    }
+                    catch(NoSuchMethodException e2) {
+                        Class<?> aClass = Class.forName("java.nio.MemoryBlock");
+                        mbWrap = aClass.getDeclaredMethod("wrapFromJni", int.class, long.class);
+                        mbWrap.setAccessible(true);
+                        directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(aClass, int.class, int.class);
+                        constructorType = DirectBufferConstructorType.ARGS_MB_INT_INT;
+                    }
+                }
+            }
+
+            byteBufferConstructor = directByteBufferConstructor;
+            directBufferConstructorType = constructorType;
+            memoryBlockWrapFromJni = mbWrap;
+
+            if(byteBufferConstructor == null)
+                throw new RuntimeException("Constructor of DirectByteBuffer is not found");
+            byteBufferConstructor.setAccessible(true);
+        }
+        catch(Exception e) {
+
+        }
+
+        try {
+            mGetAddress = directByteBufferClass.getDeclaredMethod("address");
+            mGetAddress.setAccessible(true);
+
+            mCleaner = directByteBufferClass.getDeclaredMethod("cleaner");
+            mCleaner.setAccessible(true);
+
+            mClean = mCleaner.getReturnType().getDeclaredMethod("clean");
+            mClean.setAccessible(true);
+        }
+        catch(NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static long getAddress(Object base) {
+        try {
+            return (Long) mGetAddress.invoke(base);
+        }
+        catch(IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        catch(InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static void clean(Object base) {
+        try {
+            Object cleaner = mCleaner.invoke(base);
+            mClean.invoke(cleaner);
+        }
+        catch(Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static boolean isDirectByteBufferInstance(Object s) {
+        return directByteBufferClass.isInstance(s);
+    }
+
+    static ByteBuffer newByteBuffer(long address, int index, int length, ByteBuffer reference) {
+        try {
+            switch(directBufferConstructorType) {
+                case ARGS_LONG_INT_REF:
+                    return (ByteBuffer) byteBufferConstructor.newInstance(address + index, length, reference);
+                case ARGS_LONG_INT:
+                    return (ByteBuffer) byteBufferConstructor.newInstance(address + index, length);
+                case ARGS_INT_INT:
+                    return (ByteBuffer) byteBufferConstructor.newInstance((int) address + index, length);
+                case ARGS_MB_INT_INT:
+                    return (ByteBuffer) byteBufferConstructor.newInstance(
+                        memoryBlockWrapFromJni.invoke(null, address + index, length),
+                        length, 0);
+                default:
+                    throw new IllegalStateException("Unexpected value");
+            }
+        }
+        catch(Throwable e) {
+            // Convert checked exception to unchecked exception
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
@@ -69,12 +69,7 @@ class DirectBufferAccess {
             if(byteBufferConstructor == null)
                 throw new RuntimeException("Constructor of DirectByteBuffer is not found");
             byteBufferConstructor.setAccessible(true);
-        }
-        catch(Exception e) {
 
-        }
-
-        try {
             mGetAddress = directByteBufferClass.getDeclaredMethod("address");
             mGetAddress.setAccessible(true);
 
@@ -84,7 +79,7 @@ class DirectBufferAccess {
             mClean = mCleaner.getReturnType().getDeclaredMethod("clean");
             mClean.setAccessible(true);
         }
-        catch(NoSuchMethodException e) {
+        catch(Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -5,12 +5,9 @@ import sun.misc.Unsafe;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.security.AccessControlException;
 
 import static org.msgpack.core.Preconditions.*;
 
@@ -26,17 +23,9 @@ public class MessageBuffer {
 
     static final boolean isUniversalBuffer;
     static final Unsafe unsafe;
-    // TODO We should use MethodHandle for efficiency, but it is not available in JDK6
+
     static final int ARRAY_BYTE_BASE_OFFSET;
     static final int ARRAY_BYTE_INDEX_SCALE;
-
-    enum DirectBufferConstructorType {
-        ARGS_LONG_INT_REF,
-        ARGS_LONG_INT,
-        ARGS_INT_INT,
-        ARGS_MB_INT_INT,
-        NONE
-    }
 
     static {
         try {
@@ -135,133 +124,6 @@ public class MessageBuffer {
     }
 
     /**
-     * Wraps the difference of access methods to DirectBuffers between Android and others.
-     */
-    private static class DirectBufferAccess {
-        static Method mGetAddress;
-        static Method mCleaner;
-        static Method mClean;
-
-        static Constructor byteBufferConstructor;
-
-        static Class<?> directByteBufferClass;
-        static DirectBufferConstructorType directBufferConstructorType;
-        static Method memoryBlockWrapFromJni;
-
-        static {
-            try {
-                if(!isUniversalBuffer) {
-                    try {
-                        // Find the hidden constructor for DirectByteBuffer
-                        directByteBufferClass = ClassLoader.getSystemClassLoader().loadClass("java.nio.DirectByteBuffer");
-                        Constructor directByteBufferConstructor = null;
-                        DirectBufferConstructorType constructorType = null;
-                        Method mbWrap = null;
-                        try {
-                            // TODO We should use MethodHandle for Java7, which can avoid the cost of boxing with JIT optimization
-                            directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(long.class, int.class, Object.class);
-                            constructorType = DirectBufferConstructorType.ARGS_LONG_INT_REF;
-                        }
-                        catch(NoSuchMethodException e0) {
-                            try {
-                                // https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/java/nio/DirectByteBuffer.java
-                                // DirectByteBuffer(long address, int capacity)
-                                directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(long.class, int.class);
-                                constructorType = DirectBufferConstructorType.ARGS_LONG_INT;
-                            }
-                            catch(NoSuchMethodException e1) {
-                                try {
-                                    directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(int.class, int.class);
-                                    constructorType = DirectBufferConstructorType.ARGS_INT_INT;
-                                }
-                                catch(NoSuchMethodException e2) {
-                                    Class<?> aClass = Class.forName("java.nio.MemoryBlock");
-                                    mbWrap = aClass.getDeclaredMethod("wrapFromJni", int.class, long.class);
-                                    mbWrap.setAccessible(true);
-                                    directByteBufferConstructor = directByteBufferClass.getDeclaredConstructor(aClass, int.class, int.class);
-                                    constructorType = DirectBufferConstructorType.ARGS_MB_INT_INT;
-                                }
-                            }
-                        }
-
-                        byteBufferConstructor = directByteBufferConstructor;
-                        directBufferConstructorType = constructorType;
-                        memoryBlockWrapFromJni = mbWrap;
-
-                        if(byteBufferConstructor == null)
-                            throw new RuntimeException("Constructor of DirectByteBuffer is not found");
-                        byteBufferConstructor.setAccessible(true);
-                    }
-                    catch(Exception e) {
-                        directBufferConstructorType = DirectBufferConstructorType.NONE;
-                    }
-                }
-
-                mGetAddress = directByteBufferClass.getDeclaredMethod("address");
-                mGetAddress.setAccessible(true);
-
-                mCleaner = directByteBufferClass.getDeclaredMethod("cleaner");
-                mCleaner.setAccessible(true);
-
-                mClean = mCleaner.getReturnType().getDeclaredMethod("clean");
-                mClean.setAccessible(true);
-            }
-            catch(NoSuchMethodException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        static long getAddress(Object base) {
-            try {
-                return (Long) mGetAddress.invoke(base);
-            }
-            catch(IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-            catch(InvocationTargetException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        static void clean(Object base) {
-            try {
-                Object cleaner = mCleaner.invoke(base);
-                mClean.invoke(cleaner);
-            }
-            catch(Throwable e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        static boolean isDirectByteBufferInstance(Object s) {
-            return directByteBufferClass.isInstance(s);
-        }
-
-        static ByteBuffer newByteBuffer(long address, int index, int length, ByteBuffer reference) {
-            try {
-                switch(directBufferConstructorType) {
-                    case ARGS_LONG_INT_REF:
-                        return (ByteBuffer) byteBufferConstructor.newInstance(address + index, length, reference);
-                    case ARGS_LONG_INT:
-                        return (ByteBuffer) byteBufferConstructor.newInstance(address + index, length);
-                    case ARGS_INT_INT:
-                        return (ByteBuffer) byteBufferConstructor.newInstance((int) address + index, length);
-                    case ARGS_MB_INT_INT:
-                        return (ByteBuffer) byteBufferConstructor.newInstance(
-                            memoryBlockWrapFromJni.invoke(null, address + index, length),
-                            length, 0);
-                    default:
-                        throw new IllegalStateException("Unexpected value");
-                }
-            }
-            catch(Throwable e) {
-                // Convert checked exception to unchecked exception
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    /**
      * MessageBuffer class to use. If this machine is big-endian, it uses MessageBufferBE, which overrides some methods in this class that translate endians. If not, uses MessageBuffer.
      */
     private final static Class<?> msgBufferClass;
@@ -294,10 +156,6 @@ public class MessageBuffer {
      * released by the garbage collector.
      */
     protected final ByteBuffer reference;
-
-    // TODO life-time management of this buffer
-    //private AtomicInteger referenceCounter;
-
 
     static MessageBuffer newOffHeapBuffer(int length) {
         // This method is not available in Android OS
@@ -362,7 +220,7 @@ public class MessageBuffer {
     }
 
     public static void releaseBuffer(MessageBuffer buffer) {
-        if(buffer.base instanceof byte[]) {
+        if(isUniversalBuffer || buffer.base instanceof byte[]) {
             // We have nothing to do. Wait until the garbage-collector collects this array object
         }
         else if(DirectBufferAccess.isDirectByteBufferInstance(buffer.base)) {
@@ -394,6 +252,9 @@ public class MessageBuffer {
      */
     MessageBuffer(ByteBuffer bb) {
         if(bb.isDirect()) {
+            if(isUniversalBuffer) {
+                throw new IllegalStateException("Cannot create MessageBuffer from DirectBuffer");
+            }
             // Direct buffer or off-heap memory
             this.base = null;
             this.address = DirectBufferAccess.getAddress(bb);

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -406,6 +406,7 @@ public class MessageBuffer {
 
     public void putByteBuffer(int index, ByteBuffer src, int len) {
         assert (len <= src.remaining());
+        assert (!isUniversalBuffer);
 
         if(src.isDirect()) {
             unsafe.copyMemory(null, DirectBufferAccess.getAddress(src) + src.position(), base, address + index, len);
@@ -439,6 +440,7 @@ public class MessageBuffer {
             return ByteBuffer.wrap((byte[]) base, (int) ((address - ARRAY_BYTE_BASE_OFFSET) + index), length);
         }
         else {
+            assert (!isUniversalBuffer);
             return DirectBufferAccess.newByteBuffer(address, index, length, reference);
         }
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -85,7 +85,6 @@ public class MessageBuffer {
                 }
 
                 // Fetch theUnsafe object for Oracle and OpenJDK
-                Unsafe u;
                 Field field = Unsafe.class.getDeclaredField("theUnsafe");
                 field.setAccessible(true);
                 unsafe = (Unsafe) field.get(null);

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -59,23 +59,26 @@ public class MessageBuffer {
 
             boolean hasUnsafe = false;
             try {
-                Class.forName("sun.misc.Unsafe");
-                hasUnsafe = true;
+                hasUnsafe = Class.forName("sun.misc.Unsafe") != null;
             }
-            catch(ClassNotFoundException e) {
+            catch(Exception e) {
             }
 
             // Detect android VM
             boolean isAndroid = System.getProperty("java.runtime.name", "").toLowerCase().contains("android");
 
+            // Is Google App Engine?
+            boolean isGAE = System.getProperty("com.google.appengine.runtime.version") != null;
+
             // For Java6, android and JVM that has no Unsafe class, use Universal MessageBuffer
             boolean useUniversalBuffer =
                 Boolean.parseBoolean(System.getProperty("msgpack.universal-buffer", "false"))
                     || isAndroid
+                    || isGAE
                     || !isJavaAtLeast7
                     || !hasUnsafe;
 
-            // We need to use reflection to find MessageBuffer implementation classes because
+            // We need to use reflection to find MessageBuffer implementation classes abecause
             // importing these classes creates TypeProfile and adds some overhead to method calls.
             String bufferClsName;
             if(useUniversalBuffer) {


### PR DESCRIPTION
Fixes for #194: 
- Refactored MessageBuffer to isolate the initialization steps between standard and Java6/Android/GAE platforms. 
- Extracted DirectBufferAccess code to a new file. 

I confirmed with this fix, we can initialize MessageBuffer class in GAE platform. 