### PR TITLE
Disable TravisCI e-mail notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,3 @@ branches:
     - /^v07.*$/
 
 script: sbt ++$TRAVIS_SCALA_VERSION test
-
-notifications:
-  email:
-    - ozawa.tsuyoshi@gmail.com
-    - leo@xerial.org
-    - komamitsu@gmail.com


### PR DESCRIPTION
The current TravisCI e-mail notification setting is effective even to forked repositories. Even if we remove this settings, we still can see the build failure in pull-request page. And also we can use an icon like this  [![Travis CI](https://travis-ci.org/msgpack/msgpack-java.svg?branch=v07-develop)](https://travis-ci.org/msgpack/msgpack-java) to notify build failure. 

