### PR TITLE
Make MessagePackParser#getEmbeddedObject return MessagePackExtendedType

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackExtendedType.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackExtendedType.java
@@ -1,0 +1,25 @@
+package org.msgpack.jackson.dataformat;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Created by komamitsu on 3/7/15.
+ */
+public class MessagePackExtendedType {
+    private final int extType;
+    private final ByteBuffer byteBuffer;
+
+    public MessagePackExtendedType(int extType, ByteBuffer byteBuffer) {
+        this.extType = extType;
+        this.byteBuffer = byteBuffer.isReadOnly() ?
+                byteBuffer : byteBuffer.asReadOnlyBuffer();
+    }
+
+    public int extType() {
+        return extType;
+    }
+
+    public ByteBuffer byteBuffer() {
+        return byteBuffer;
+    }
+}

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
@@ -10,6 +10,7 @@ import org.msgpack.core.MessageUnpacker;
 import org.msgpack.core.buffer.ArrayBufferInput;
 import org.msgpack.core.buffer.InputStreamBufferInput;
 import org.msgpack.core.buffer.MessageBufferInput;
+import org.msgpack.value.ExtendedValue;
 import org.msgpack.value.ValueRef;
 import org.msgpack.value.NumberValue;
 import org.msgpack.value.ValueType;
@@ -272,11 +273,14 @@ public class MessagePackParser extends ParserMinimalBase {
         ValueRef ref = valueHolder.getRef();
 
         if (ref.isBinary()) {
-          return ref.asBinary().toByteArray();
+            return ref.asBinary().toByteArray();
         } else if (ref.isExtended()) {
-          return ref.asExtended().toValue();
+            ExtendedValue extendedValue = ref.asExtended().toValue();
+            MessagePackExtendedType extendedType =
+                    new MessagePackExtendedType(extendedValue.getExtType(), extendedValue.toByteBuffer());
+            return extendedType;
         } else {
-          throw new UnsupportedOperationException();
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackExtendedTypeTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackExtendedTypeTest.java
@@ -1,0 +1,60 @@
+package org.msgpack.jackson.dataformat;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.*;
+
+public class MessagePackExtendedTypeTest {
+    private void assertExtendedType(MessagePackExtendedType x,
+                                    int expectedExtType, ByteBuffer expectedByteBuffer) {
+        assertEquals(expectedExtType, x.extType());
+        assertEquals(expectedByteBuffer, x.byteBuffer());
+        assertTrue(x.byteBuffer().isReadOnly());
+    }
+
+    @Test
+    public void testMessagePackExtendedType() {
+        byte[] bs = new byte[] {0x00, (byte) 0xCC, (byte) 0xFF};
+        ByteBuffer expectedByteBuffer = ByteBuffer.wrap(bs);
+
+        int extType = 1;
+        MessagePackExtendedType extendedType =
+                new MessagePackExtendedType(extType, ByteBuffer.wrap(bs));
+        assertExtendedType(extendedType, extType, expectedByteBuffer);
+
+        extType = 2;
+        ByteBuffer bb = ByteBuffer.allocate(3);
+        bb.put(bs);
+        bb.position(0);
+        extendedType = new MessagePackExtendedType(extType, bb);
+        assertExtendedType(extendedType, extType, expectedByteBuffer);
+
+        extType = 3;
+        bb = ByteBuffer.allocateDirect(3);
+        bb.put(bs);
+        bb.position(0);
+        extendedType = new MessagePackExtendedType(extType, bb);
+        assertExtendedType(extendedType, extType, expectedByteBuffer);
+
+        extType = -1;
+        extendedType =
+                new MessagePackExtendedType(extType, ByteBuffer.wrap(bs).asReadOnlyBuffer());
+        assertExtendedType(extendedType, extType, expectedByteBuffer);
+
+        extType = -2;
+        bb = ByteBuffer.allocate(3);
+        bb.put(bs);
+        bb.position(0);
+        extendedType = new MessagePackExtendedType(extType, bb.asReadOnlyBuffer());
+        assertExtendedType(extendedType, extType, expectedByteBuffer);
+
+        extType = -3;
+        bb = ByteBuffer.allocateDirect(3);
+        bb.put(bs);
+        bb.position(0);
+        extendedType = new MessagePackExtendedType(extType, bb.asReadOnlyBuffer());
+        assertExtendedType(extendedType, extType, expectedByteBuffer);
+    }
+}

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
@@ -11,6 +11,7 @@ import org.msgpack.value.ExtendedValue;
 
 import java.io.*;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class MessagePackParserTest extends MessagePackDataformatTestBase {
         // #9
         byte[] extPayload = {-80, -50, -25, -114, -25, 16, 60, 68};
         packer.packString("ext");
-        packer.packExtendedTypeHeader(2, extPayload.length);
+        packer.packExtendedTypeHeader(0, extPayload.length);
         packer.writePayload(extPayload);
 
         packer.flush();
@@ -138,7 +139,9 @@ public class MessagePackParserTest extends MessagePackDataformatTestBase {
             else if (k.equals("ext")) {
                 // #9
                 bitmap |= 1 << 10;
-                assertArrayEquals(extPayload, ((ExtendedValue) v).toByteArray());
+                MessagePackExtendedType extendedType = (MessagePackExtendedType) v;
+                assertEquals(0, extendedType.extType());
+                assertEquals(ByteBuffer.wrap(extPayload), extendedType.byteBuffer());
             }
         }
         assertEquals(0x7FF, bitmap);
@@ -185,7 +188,7 @@ public class MessagePackParserTest extends MessagePackDataformatTestBase {
         packer.packBoolean(true);
         // #11
         byte[] extPayload = {-80, -50, -25, -114, -25, 16, 60, 68};
-        packer.packExtendedTypeHeader(2, extPayload.length);
+        packer.packExtendedTypeHeader(-1, extPayload.length);
         packer.writePayload(extPayload);
 
         packer.flush();
@@ -243,7 +246,9 @@ public class MessagePackParserTest extends MessagePackDataformatTestBase {
         // #10
         assertEquals(true, array.get(i++));
         // #11
-        assertArrayEquals(extPayload, ((ExtendedValue) array.get(i++)).toByteArray());
+        MessagePackExtendedType extendedType = (MessagePackExtendedType) array.get(i++);
+        assertEquals(-1, extendedType.extType());
+        assertEquals(ByteBuffer.wrap(extPayload), extendedType.byteBuffer());
     }
 
     @Test


### PR DESCRIPTION
In https://github.com/msgpack/msgpack-java/pull/201, we made `org.msgpack.jackson.dataformat.MessagePackParser#getEmbeddedObject` return `org.msgpack.value.ExtendedValue` directly. But `org.msgpack.value.ExtendedValue` shouldn't be exposed from `org.msgpack.jackson.dataformat`, I think. Also, wrapping it with `MessagePackExtendedType` would be useful when the implementation of `org.msgpack.value.ExtendedValue` changes.