### PR TITLE
Fixing the contract of nextToken to be compliant with com.fasterxml.jackson.core.JsonParser.nextToken(), fixes #206

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
@@ -118,6 +118,10 @@ public class MessagePackParser extends ParserMinimalBase {
             }
         }
 
+        if (!messageUnpacker.hasNext()) {
+            return null;
+        }
+
         MessageFormat nextFormat = messageUnpacker.getNextFormat();
         ValueType valueType = nextFormat.getValueType();
 

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 public class MessagePackParserTest extends MessagePackDataformatTestBase {
     @Test
@@ -309,13 +310,8 @@ public class MessagePackParserTest extends MessagePackDataformatTestBase {
         assertEquals(-1, parser.getCurrentLocation().getLineNr());
         assertEquals(16, parser.getCurrentLocation().getColumnNr());
 
-        try {
-            parser.nextToken();
-            assertTrue(false);
-        }
-        catch (EOFException e) {
-            // Expected
-        }
+        assertNull(parser.nextToken());
+
         parser.close();
         parser.close(); // Intentional
     }


### PR DESCRIPTION
Fixing the contract of nextToken to be compliant with com.fasterxml.jackson.core.JsonParser.nextToken() and not throw an EOFException if at the end of the stream. fixes #206 