### PR TITLE
Upgrade to sbt-sonatype-0.5.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,8 @@ import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.ReleaseStep
 import scala.util.Properties
 import com.typesafe.sbt.pgp.PgpKeys
-import xerial.sbt.Sonatype.SonatypeKeys._
+import xerial.sbt.Sonatype
+import Sonatype.SonatypeKeys._
 
 object Build extends Build {
 
@@ -50,13 +51,6 @@ object Build extends Build {
       concurrentRestrictions in Global := Seq(
         Tags.limit(Tags.Test, 1)
       ),
-      publishTo := {
-        val nexus = "https://oss.sonatype.org/"
-        if (isSnapshot.value)
-          Some("snapshots" at nexus + "content/repositories/snapshots")
-        else
-          Some("releases" at nexus + "service/local/staging/deploy/maven2")
-      },
       ReleaseKeys.tagName <<= (version in ThisBuild) map (v => v),
       ReleaseKeys.releaseProcess := Seq[ReleaseStep](
         checkSnapshotDependencies,
@@ -95,51 +89,7 @@ object Build extends Build {
           opts
       },
       findbugsReportType := Some(ReportType.FancyHtml),
-      findbugsReportPath := Some(crossTarget.value / "findbugs" / "report.html"),
-      pomExtra := {
-        <url>http://msgpack.org/</url>
-          <licenses>
-            <license>
-              <name>Apache 2</name>
-              <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            </license>
-          </licenses>
-          <scm>
-            <connection>scm:git:github.com/msgpack/msgpack-java.git</connection>
-            <developerConnection>scm:git:git@github.com:msgpack/msgpack-java.git</developerConnection>
-            <url>github.com/msgpack/msgpack-java.git</url>
-          </scm>
-          <properties>
-            <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-          </properties>
-          <developers>
-            <developer>
-              <id>frsyuki</id>
-              <name>Sadayuki Furuhashi</name>
-              <email>frsyuki@users.sourceforge.jp</email>
-            </developer>
-            <developer>
-              <id>muga</id>
-              <name>Muga Nishizawa</name>
-              <email>muga.nishizawa@gmail.com</email>
-            </developer>
-            <developer>
-              <id>oza</id>
-              <name>Tsuyoshi Ozawa</name>
-              <url>https://github.com/oza</url>
-            </developer>
-            <developer>
-              <id>komamitsu</id>
-              <name>Mitsunori Komatsu</name>
-              <email>komamitsu@gmail.com</email>
-            </developer>
-            <developer>
-              <id>xerial</id>
-              <name>Taro L. Saito</name>
-              <email>leo@xerial.org</email>
-            </developer>
-          </developers>
-      }
+      findbugsReportPath := Some(crossTarget.value / "findbugs" / "report.html")
     )
 
   import Dependencies._
@@ -167,7 +117,7 @@ object Build extends Build {
       description := "Core library of the MessagePack for Java",
       libraryDependencies ++= testLib
     )
-  )
+  ).disablePlugins(Sonatype)
 
   lazy val msgpackJackson = Project(
     id = "msgpack-jackson",
@@ -178,7 +128,7 @@ object Build extends Build {
       libraryDependencies ++= jacksonLib,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
     )
-  ).dependsOn(msgpackCore)
+  ).disablePlugins(Sonatype).dependsOn(msgpackCore)
 
   object Dependencies {
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,8 +25,6 @@ import sbtrelease.ReleasePlugin._
 import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.ReleaseStep
 import scala.util.Properties
-import com.typesafe.sbt.pgp.PgpKeys
-import xerial.sbt.Sonatype.SonatypeKeys._
 
 object Build extends Build {
 
@@ -42,7 +40,6 @@ object Build extends Build {
       organizationHomepage := Some(new URL("http://msgpack.org/")),
       description := "MessagePack for Java",
       scalaVersion in Global := SCALA_VERSION,
-      ReleaseKeys.publishArtifactsAction := PgpKeys.publishSigned.value,
       logBuffered in Test := false,
       //parallelExecution in Test := false,
       autoScalaLibrary := false,
@@ -59,18 +56,10 @@ object Build extends Build {
         setReleaseVersion,
         commitReleaseVersion,
         tagRelease,
-        ReleaseStep(
-          action = { state =>
-            val extracted = Project extract state
-            extracted.runAggregated(PgpKeys.publishSigned in Global in extracted.get(thisProjectRef), state)
-          }
-        ),
+        ReleaseStep(action = Command.process("publishSigned", _)),
         setNextVersion,
         commitNextVersion,
-        ReleaseStep{ state =>
-          val extracted = Project extract state
-          extracted.runAggregated(sonatypeReleaseAll in Global in extracted.get(thisProjectRef), state)
-        },
+        ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
         pushChanges
       ),
       parallelExecution in jacoco.Config := false,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,8 +26,7 @@ import sbtrelease.ReleaseStateTransformations._
 import sbtrelease.ReleaseStep
 import scala.util.Properties
 import com.typesafe.sbt.pgp.PgpKeys
-import xerial.sbt.Sonatype
-import Sonatype.SonatypeKeys._
+import xerial.sbt.Sonatype.SonatypeKeys._
 
 object Build extends Build {
 
@@ -94,21 +93,19 @@ object Build extends Build {
 
   import Dependencies._
 
-
   lazy val root = Project(
     id = "msgpack-java",
     base = file("."),
     settings = buildSettings ++ Seq(
-      findbugs := {
-        // do not run findbugs for the root project
-      },
       // Do not publish the root project
       publishArtifact := false,
       publish := {},
-      publishLocal := {}
+      publishLocal := {},
+      findbugs := {
+        // do not run findbugs for the root project
+      }
     )
-  ) aggregate(msgpackCore, msgpackJackson)
-
+  ).aggregate(msgpackCore, msgpackJackson)
 
   lazy val msgpackCore = Project(
     id = "msgpack-core",
@@ -117,7 +114,7 @@ object Build extends Build {
       description := "Core library of the MessagePack for Java",
       libraryDependencies ++= testLib
     )
-  ).disablePlugins(Sonatype)
+  )
 
   lazy val msgpackJackson = Project(
     id = "msgpack-jackson",
@@ -128,7 +125,7 @@ object Build extends Build {
       libraryDependencies ++= jacksonLib,
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
     )
-  ).disablePlugins(Sonatype).dependsOn(msgpackCore)
+  ).dependsOn(msgpackCore)
 
   object Dependencies {
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.3.3")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.4.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.3.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.4.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 

--- a/sbt
+++ b/sbt
@@ -119,7 +119,7 @@ init_default_option_file () {
 
 declare -r cms_opts="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 declare -r jit_opts="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation"
-declare -r default_jvm_opts="-ea -Dfile.encoding=UTF8 -XX:MaxPermSize=384m -Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
+declare -r default_jvm_opts="-ea -Dfile.encoding=UTF8 -Xms512m -Xmx1536m -Xss2m $jit_opts $cms_opts"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
 declare -r latest_28="2.8.2"
 declare -r latest_29="2.9.3"

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,4 +1,4 @@
-import SonatypeKeys._
+Sonatype.sonatypeSettings
 
 sonatypeProfileName := "org.msgpack"
 

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,1 +1,48 @@
-sonatypeSettings
+import SonatypeKeys._
+
+sonatypeProfileName := "org.msgpack"
+
+pomExtra := {
+  <url>http://msgpack.org/</url>
+    <licenses>
+      <license>
+        <name>Apache 2</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+    </licenses>
+    <scm>
+      <connection>scm:git:github.com/msgpack/msgpack-java.git</connection>
+      <developerConnection>scm:git:git@github.com:msgpack/msgpack-java.git</developerConnection>
+      <url>github.com/msgpack/msgpack-java.git</url>
+    </scm>
+    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <developers>
+      <developer>
+        <id>frsyuki</id>
+        <name>Sadayuki Furuhashi</name>
+        <email>frsyuki@users.sourceforge.jp</email>
+      </developer>
+      <developer>
+        <id>muga</id>
+        <name>Muga Nishizawa</name>
+        <email>muga.nishizawa@gmail.com</email>
+      </developer>
+      <developer>
+        <id>oza</id>
+        <name>Tsuyoshi Ozawa</name>
+        <url>https://github.com/oza</url>
+      </developer>
+      <developer>
+        <id>komamitsu</id>
+        <name>Mitsunori Komatsu</name>
+        <email>komamitsu@gmail.com</email>
+      </developer>
+      <developer>
+        <id>xerial</id>
+        <name>Taro L. Saito</name>
+        <email>leo@xerial.org</email>
+      </developer>
+    </developers>
+}

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,5 +1,3 @@
-Sonatype.sonatypeSettings
-
 sonatypeProfileName := "org.msgpack"
 
 pomExtra := {


### PR DESCRIPTION
Upgrade to sbt-sonatype-0.5.0 
- This version improves error handling on 500 error when accessing sonatype REST API. 
- Extract sbt-sonatype related setting into sonatype.sbt
- Enables sonatype related commands (e.g., sonatypeRelease) only at the root project
- publishTo setting is not longer necessary (sbt-sonatype sets this)