### PR TITLE
Add universal buffer test instead of using jdk6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: scala
-scala:
-   - 2.11.1
 
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk7
   - oraclejdk8
@@ -12,4 +9,6 @@ branches:
   only:
     - /^v07.*$/
 
-script: sbt ++$TRAVIS_SCALA_VERSION test
+script:
+  - sbt test
+  - sbt test -J-Dmsgpack.universal-buffer=true

--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala
@@ -11,6 +11,11 @@ class MessageBufferTest extends MessagePackSpec {
 
   "MessageBuffer" should {
 
+    "check buffer type" in {
+      val b = MessageBuffer.newBuffer(0)
+      info(s"MessageBuffer type: ${b.getClass.getName}")
+    }
+
     "wrap ByteBuffer considering position and remaining values" taggedAs("wrap-bb") in {
       val d = Array[Byte](10,11,12,13,14,15,16,17,18,19)
       val subset = ByteBuffer.wrap(d, 2, 2)

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,6 +1,6 @@
 sonatypeProfileName := "org.msgpack"
 
-pomExtra := {
+pomExtra in Global := {
   <url>http://msgpack.org/</url>
     <licenses>
       <license>


### PR DESCRIPTION
- Fixes .travis.yml config not to use jdk6. This is necessary to run the latest version of checkstyle 
- Add test that uses MessageBufferU for emulating jdk6 and Android 