### PR TITLE
Fixes #38: Add IntegerValue.mostSuccinctMessageFormat

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -423,7 +423,7 @@ public class MessagePacker
             writeByteAndLong(UINT64, bi.longValue());
         }
         else {
-            throw new IllegalArgumentException("Messagepack cannot serialize BigInteger larger than 2^64-1");
+            throw new IllegalArgumentException("MessagePack cannot serialize BigInteger larger than 2^64-1");
         }
         return this;
     }

--- a/msgpack-core/src/main/java/org/msgpack/value/IntegerValue.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/IntegerValue.java
@@ -15,6 +15,8 @@
 //
 package org.msgpack.value;
 
+import org.msgpack.core.MessageFormat;
+
 import java.math.BigInteger;
 
 /**
@@ -44,6 +46,12 @@ public interface IntegerValue
      * Returns true if the value is in the range of [-2<sup>63</sup> to 2<sup>63</sup>-1]
      */
     boolean isInLongRange();
+
+    /**
+     * Returns the most succinct MessageFormat type to represent this integer value.
+     * @return
+     */
+    MessageFormat mostSuccinctMessageFormat();
 
     /**
      * Returns the value as a {@code byte}, otherwise throws an exception.

--- a/msgpack-core/src/main/java/org/msgpack/value/Variable.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/Variable.java
@@ -15,11 +15,13 @@
 //
 package org.msgpack.value;
 
+import org.msgpack.core.MessageFormat;
 import org.msgpack.core.MessageIntegerOverflowException;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageStringCodingException;
 import org.msgpack.core.MessageTypeCastException;
+import org.msgpack.value.impl.ImmutableBigIntegerValueImpl;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -513,6 +515,12 @@ public class Variable
                 return false;
             }
             return true;
+        }
+
+        @Override
+        public MessageFormat mostSuccinctMessageFormat()
+        {
+            return ImmutableBigIntegerValueImpl.mostSuccinctMessageFormat(this);
         }
 
         @Override

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableBigIntegerValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableBigIntegerValueImpl.java
@@ -15,6 +15,7 @@
 //
 package org.msgpack.value.impl;
 
+import org.msgpack.core.MessageFormat;
 import org.msgpack.core.MessageIntegerOverflowException;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.value.ImmutableIntegerValue;
@@ -35,6 +36,26 @@ public class ImmutableBigIntegerValueImpl
         extends AbstractImmutableValue
         implements ImmutableIntegerValue
 {
+    public static MessageFormat mostSuccinctMessageFormat(IntegerValue v)
+    {
+        if(v.isInByteRange()) {
+            return MessageFormat.INT8;
+        }
+        else if(v.isInShortRange()) {
+            return MessageFormat.INT16;
+        }
+        else if(v.isInIntRange()) {
+            return MessageFormat.INT32;
+        }
+        else if(v.isInLongRange()) {
+            return MessageFormat.INT64;
+        }
+        else {
+            return MessageFormat.UINT64;
+        }
+    }
+
+
     private final BigInteger value;
 
     public ImmutableBigIntegerValueImpl(BigInteger value)
@@ -139,6 +160,12 @@ public class ImmutableBigIntegerValueImpl
     public boolean isInLongRange()
     {
         return 0 <= value.compareTo(LONG_MIN) && value.compareTo(LONG_MAX) <= 0;
+    }
+
+    @Override
+    public MessageFormat mostSuccinctMessageFormat()
+    {
+        return mostSuccinctMessageFormat(this);
     }
 
     @Override

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableLongValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableLongValueImpl.java
@@ -15,6 +15,7 @@
 //
 package org.msgpack.value.impl;
 
+import org.msgpack.core.MessageFormat;
 import org.msgpack.core.MessageIntegerOverflowException;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.value.ImmutableIntegerValue;
@@ -137,6 +138,12 @@ public class ImmutableLongValueImpl
     public boolean isInLongRange()
     {
         return true;
+    }
+
+    @Override
+    public MessageFormat mostSuccinctMessageFormat()
+    {
+        return ImmutableBigIntegerValueImpl.mostSuccinctMessageFormat(this);
     }
 
     @Override

--- a/msgpack-core/src/test/scala/org/msgpack/value/ValueTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/ValueTest.scala
@@ -24,11 +24,15 @@ class ValueTest extends MessagePackSpec
   def checkSuccinctType(pack:MessagePacker => Unit, expectedAtMost:MessageFormat) {
     val b = createMessagePackData(pack)
     val v1 = MessagePack.newDefaultUnpacker(b).unpackValue()
-    v1.asIntegerValue().mostSuccinctMessageFormat().ordinal() shouldBe <= (expectedAtMost.ordinal())
+    val mf = v1.asIntegerValue().mostSuccinctMessageFormat()
+    mf.getValueType shouldBe ValueType.INTEGER
+    mf.ordinal() shouldBe <= (expectedAtMost.ordinal())
 
     val v2 = new Variable
     MessagePack.newDefaultUnpacker(b).unpackValue(v2)
-    v2.asIntegerValue().mostSuccinctMessageFormat().ordinal() shouldBe <= (expectedAtMost.ordinal())
+    val mf2 = v2.asIntegerValue().mostSuccinctMessageFormat()
+    mf2.getValueType shouldBe ValueType.INTEGER
+    mf2.ordinal() shouldBe <= (expectedAtMost.ordinal())
   }
 
   "Value" should {

--- a/msgpack-core/src/test/scala/org/msgpack/value/ValueTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/value/ValueTest.scala
@@ -1,0 +1,49 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.value
+
+import java.math.BigInteger
+
+import org.msgpack.core._
+
+class ValueTest extends MessagePackSpec
+{
+  def checkSuccinctType(pack:MessagePacker => Unit, expectedAtMost:MessageFormat) {
+    val b = createMessagePackData(pack)
+    val v1 = MessagePack.newDefaultUnpacker(b).unpackValue()
+    v1.asIntegerValue().mostSuccinctMessageFormat().ordinal() shouldBe <= (expectedAtMost.ordinal())
+
+    val v2 = new Variable
+    MessagePack.newDefaultUnpacker(b).unpackValue(v2)
+    v2.asIntegerValue().mostSuccinctMessageFormat().ordinal() shouldBe <= (expectedAtMost.ordinal())
+  }
+
+  "Value" should {
+    "tell most succinct integer type" in {
+      forAll { (v: Byte) => checkSuccinctType(_.packByte(v), MessageFormat.INT8) }
+      forAll { (v: Short) => checkSuccinctType(_.packShort(v), MessageFormat.INT16) }
+      forAll { (v: Int) => checkSuccinctType(_.packInt(v), MessageFormat.INT32) }
+      forAll { (v: Long) => checkSuccinctType(_.packLong(v), MessageFormat.INT64) }
+      forAll { (v: Long) => checkSuccinctType(_.packBigInteger(BigInteger.valueOf(v)), MessageFormat.INT64) }
+      forAll { (v: Long) =>
+        whenever(v > 0) {
+          // Create value between 2^63-1 < v <= 2^64-1
+          checkSuccinctType(_.packBigInteger(BigInteger.valueOf(Long.MaxValue).add(BigInteger.valueOf(v))), MessageFormat.UINT64)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a utility method to IntegerValue to detect the most succinct integer type. This is useful when user wants to know which get method (e.g., getByte, getInt, etc. ) should be used to extract values.  