### PR TITLE
Rename Extended to Extension

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackExtensionType.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackExtensionType.java
@@ -37,8 +37,8 @@ public class MessagePackExtensionType
                 throws IOException, JsonProcessingException
         {
             if (gen instanceof MessagePackGenerator) {
-                MessagePackGenerator msgpackGenerator = (MessagePackGenerator)gen;
-                msgpackGenerator.writeExtendedType(value);
+                MessagePackGenerator msgpackGenerator = (MessagePackGenerator) gen;
+                msgpackGenerator.writeExtensionType(value);
             }
             else {
                 throw new IllegalStateException("'gen' is expected to be MessagePackGenerator but it's " + gen.getClass());

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -214,9 +214,9 @@ public class MessagePackGenerator
             messagePacker.packBoolean((Boolean) v);
         }
         else if (v instanceof MessagePackExtensionType) {
-            MessagePackExtensionType extendedType = (MessagePackExtensionType) v;
-            byte[] extData = extendedType.getData();
-            messagePacker.packExtensionTypeHeader((byte)extendedType.getType(), extData.length);
+            MessagePackExtensionType extensionType = (MessagePackExtensionType) v;
+            byte[] extData = extensionType.getData();
+            messagePacker.packExtensionTypeHeader(extensionType.getType(), extData.length);
             messagePacker.writePayload(extData);
         }
         else {
@@ -414,8 +414,10 @@ public class MessagePackGenerator
         addValueToStackTop(null);
     }
 
-    public void writeExtendedType(MessagePackExtensionType extendedType) throws IOException {
-        addValueToStackTop(extendedType);
+    public void writeExtensionType(MessagePackExtensionType extensionType)
+            throws IOException
+    {
+        addValueToStackTop(extensionType);
     }
 
     @Override


### PR DESCRIPTION
@komamitsu Can you look at this? #250, and #262 used extended instead of extension. This renames the few variables and methods that used it.