### PR TITLE
Fix style errors

### DIFF
--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java
@@ -72,9 +72,8 @@ public class ExampleOfTypeInformationSerDe
         }
     }
 
-
-    @JsonSerialize(using=ObjectContainerSerializer.class)
-    @JsonDeserialize(using=ObjectContainerDeserializer.class)
+    @JsonSerialize(using = ObjectContainerSerializer.class)
+    @JsonDeserialize(using = ObjectContainerDeserializer.class)
     static class ObjectContainer
     {
         private final Map<String, Object> objects;

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
@@ -672,4 +672,3 @@ public class MessagePackParserTest
         assertEquals((Integer) 3, map.get(false));
     }
 }
-


### PR DESCRIPTION
I fixed below style errors.

```
[error] src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java:73: Multiple consecutive blank lines
[error] src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java:76: '=' の前にホワイトスペースがありません。
[error] src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java:76: '=' の後にホワイトスペースがありません。
[error] src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java:77: '=' の前にホワイトスペースがありません。
[error] src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java:77: '=' の後にホワイトスペースがありません。
[info] checkstyle has succeeded
[error] src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java:673: Blank line before end of file
[trace] Stack trace suppressed: run last msgpack-jackson/test:jcheckStyle for the full output.
[error] (msgpack-jackson/test:jcheckStyle) Found 6 style error(s)
[error] Total time: 3 s, completed 2015/09/03 23:50:40
```