### PR TITLE
Simplify the config object

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -42,21 +42,36 @@ public class MessagePack
      */
     public static class Config
     {
-        private final boolean readStringAsBinary;
-        private final boolean readBinaryAsString;
-        private final CodingErrorAction onMalFormedInput;
-        private final CodingErrorAction onUnmappableCharacter;
-        private final int maxUnpackStringSize;
-        private final int stringEncoderBufferSize;
-        private final int stringDecoderBufferSize;
-        private final int packerBufferSize;
-        private final int packerRawDataCopyingThreshold;
+        /**
+         * allow unpackBinaryHeader to read str format family  (default:true)
+         */
+        public final boolean readStringAsBinary;
+        /**
+         * allow unpackRawStringHeader and unpackString to read bin format family (default: true)
+         */
+        public final boolean readBinaryAsString;
+        /**
+         * Action when encountered a malformed input
+         */
+        public final CodingErrorAction actionOnMalFormedInput;
+        /**
+         * Action when an unmappable character is found
+         */
+        public final CodingErrorAction actionOnUnmappableCharacter;
+        /**
+         * unpackString size limit. (default: Integer.MAX_VALUE)
+         */
+        public final int maxUnpackStringSize;
+        public final int stringEncoderBufferSize;
+        public final int stringDecoderBufferSize;
+        public final int packerBufferSize;
+        public final int packerRawDataCopyingThreshold;
 
         public Config(
                 boolean readStringAsBinary,
                 boolean readBinaryAsString,
-                CodingErrorAction onMalFormedInput,
-                CodingErrorAction onUnmappableCharacter,
+                CodingErrorAction actionOnMalFormedInput,
+                CodingErrorAction actionOnUnmappableCharacter,
                 int maxUnpackStringSize,
                 int stringEncoderBufferSize,
                 int stringDecoderBufferSize,
@@ -69,73 +84,13 @@ public class MessagePack
 
             this.readStringAsBinary = readStringAsBinary;
             this.readBinaryAsString = readBinaryAsString;
-            this.onMalFormedInput = onMalFormedInput;
-            this.onUnmappableCharacter = onUnmappableCharacter;
+            this.actionOnMalFormedInput = actionOnMalFormedInput;
+            this.actionOnUnmappableCharacter = actionOnUnmappableCharacter;
             this.maxUnpackStringSize = maxUnpackStringSize;
             this.stringEncoderBufferSize = stringEncoderBufferSize;
             this.stringDecoderBufferSize = stringDecoderBufferSize;
             this.packerBufferSize = packerBufferSize;
             this.packerRawDataCopyingThreshold = packerRawDataCopyingThreshold;
-        }
-
-        /**
-         * allow unpackBinaryHeader to read str format family  (default:true)
-         */
-        public boolean isReadStringAsBinary()
-        {
-            return readStringAsBinary;
-        }
-
-        /**
-         * allow unpackRawStringHeader and unpackString to read bin format family (default: true)
-         */
-        public boolean isReadBinaryAsString()
-        {
-            return readBinaryAsString;
-        }
-
-        /**
-         * Action when encountered a malformed input
-         */
-        public CodingErrorAction getActionOnMalFormedInput()
-        {
-            return onMalFormedInput;
-        }
-
-        /**
-         * Action when an unmappable character is found
-         */
-        public CodingErrorAction getActionOnUnmappableCharacter()
-        {
-            return onUnmappableCharacter;
-        }
-
-        /**
-         * unpackString size limit. (default: Integer.MAX_VALUE)
-         */
-        public int getMaxUnpackStringSize()
-        {
-            return maxUnpackStringSize;
-        }
-
-        public int getStringEncoderBufferSize()
-        {
-            return stringEncoderBufferSize;
-        }
-
-        public int getStringDecoderBufferSize()
-        {
-            return stringDecoderBufferSize;
-        }
-
-        public int getPackerBufferSize()
-        {
-            return packerBufferSize;
-        }
-
-        public int getPackerRawDataCopyingThreshold()
-        {
-            return packerRawDataCopyingThreshold;
         }
     }
 

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -150,7 +150,7 @@ public class MessagePacker
     private void prepareEncoder()
     {
         if (encoder == null) {
-            this.encoder = MessagePack.UTF8.newEncoder().onMalformedInput(config.getActionOnMalFormedInput()).onUnmappableCharacter(config.getActionOnMalFormedInput());
+            this.encoder = MessagePack.UTF8.newEncoder().onMalformedInput(config.actionOnMalFormedInput).onUnmappableCharacter(config.actionOnMalFormedInput);
         }
     }
 
@@ -158,7 +158,7 @@ public class MessagePacker
             throws IOException
     {
         if (buffer == null) {
-            buffer = out.next(config.getPackerBufferSize());
+            buffer = out.next(config.packerBufferSize);
         }
     }
 
@@ -196,7 +196,7 @@ public class MessagePacker
     {
         if (buffer == null || position + numBytesToWrite >= buffer.size()) {
             flush();
-            buffer = out.next(Math.max(config.getPackerBufferSize(), numBytesToWrite));
+            buffer = out.next(Math.max(config.packerBufferSize, numBytesToWrite));
         }
     }
 
@@ -490,8 +490,8 @@ public class MessagePacker
                 }
 
                 if (cr.isError()) {
-                    if ((cr.isMalformed() && config.getActionOnMalFormedInput() == CodingErrorAction.REPORT) ||
-                            (cr.isUnmappable() && config.getActionOnUnmappableCharacter() == CodingErrorAction.REPORT)) {
+                    if ((cr.isMalformed() && config.actionOnMalFormedInput == CodingErrorAction.REPORT) ||
+                            (cr.isUnmappable() && config.actionOnUnmappableCharacter == CodingErrorAction.REPORT)) {
                         cr.throwException();
                     }
                 }
@@ -649,7 +649,7 @@ public class MessagePacker
             throws IOException
     {
         int len = src.remaining();
-        if (len >= config.getPackerRawDataCopyingThreshold()) {
+        if (len >= config.packerRawDataCopyingThreshold) {
             // Use the source ByteBuffer directly to avoid memory copy
 
             // First, flush the current buffer contents
@@ -687,7 +687,7 @@ public class MessagePacker
     public MessagePacker writePayload(byte[] src, int off, int len)
             throws IOException
     {
-        if (len >= config.getPackerRawDataCopyingThreshold()) {
+        if (len >= config.packerRawDataCopyingThreshold) {
             // Use the input array directory to avoid memory copy
 
             // Flush the current buffer contents

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -172,10 +172,10 @@ public class MessageUnpacker
     private void prepareDecoder()
     {
         if (decoder == null) {
-            decodeBuffer = CharBuffer.allocate(config.getStringDecoderBufferSize());
+            decodeBuffer = CharBuffer.allocate(config.stringDecoderBufferSize);
             decoder = MessagePack.UTF8.newDecoder()
-                    .onMalformedInput(config.getActionOnMalFormedInput())
-                    .onUnmappableCharacter(config.getActionOnUnmappableCharacter());
+                    .onMalformedInput(config.actionOnMalFormedInput)
+                    .onUnmappableCharacter(config.actionOnUnmappableCharacter);
         }
     }
 
@@ -1011,8 +1011,8 @@ public class MessageUnpacker
     {
         int strLen = unpackRawStringHeader();
         if (strLen > 0) {
-            if (strLen > config.getMaxUnpackStringSize()) {
-                throw new MessageSizeException(String.format("cannot unpack a String of size larger than %,d: %,d", config.getMaxUnpackStringSize(), strLen), strLen);
+            if (strLen > config.maxUnpackStringSize) {
+                throw new MessageSizeException(String.format("cannot unpack a String of size larger than %,d: %,d", config.maxUnpackStringSize, strLen), strLen);
             }
 
             prepareDecoder();
@@ -1030,7 +1030,7 @@ public class MessageUnpacker
                     int readLen = Math.min(position < buffer.size() ? buffer.size() - position : buffer.size(), strLen - cursor);
                     if (hasIncompleteMultiBytes) {
                         // Prepare enough buffer for decoding multi-bytes character right after running into incomplete one
-                        readLen = Math.min(config.getStringDecoderBufferSize(), strLen - cursor);
+                        readLen = Math.min(config.stringDecoderBufferSize, strLen - cursor);
                     }
                     if (!ensure(readLen)) {
                         throw new EOFException();
@@ -1055,7 +1055,7 @@ public class MessageUnpacker
 
                         if (cr.isUnderflow() && bb.hasRemaining()) {
                             // input buffer doesn't have enough bytes for multi bytes characters
-                            if (config.getActionOnMalFormedInput() == CodingErrorAction.REPORT) {
+                            if (config.actionOnMalFormedInput == CodingErrorAction.REPORT) {
                                 throw new MalformedInputException(strLen);
                             }
                             hasIncompleteMultiBytes = true;
@@ -1064,8 +1064,8 @@ public class MessageUnpacker
                         }
 
                         if (cr.isError()) {
-                            if ((cr.isMalformed() && config.getActionOnMalFormedInput() == CodingErrorAction.REPORT) ||
-                                    (cr.isUnmappable() && config.getActionOnUnmappableCharacter() == CodingErrorAction.REPORT)) {
+                            if ((cr.isMalformed() && config.actionOnMalFormedInput == CodingErrorAction.REPORT) ||
+                                    (cr.isUnmappable() && config.actionOnUnmappableCharacter == CodingErrorAction.REPORT)) {
                                 cr.throwException();
                             }
                         }
@@ -1204,7 +1204,7 @@ public class MessageUnpacker
             return len;
         }
 
-        if (config.isReadBinaryAsString()) {
+        if (config.readBinaryAsString) {
             len = readBinaryHeader(b);
             if (len >= 0) {
                 return len;
@@ -1225,7 +1225,7 @@ public class MessageUnpacker
             return len;
         }
 
-        if (config.isReadStringAsBinary()) {
+        if (config.readStringAsBinary) {
             len = readStringHeader(b);
             if (len >= 0) {
                 return len;


### PR DESCRIPTION
This PR removes Config.getXXX. Although there is some advantage of having getters (replacing the internal field name, add a hook point in future, etc.), this config object is only used for storing configuration values, so I think reducing the code size has much advantage over these benefits.