### PR TITLE
Fix TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ branches:
     - /^v07.*$/
 
 script:
-  - sbt test
-  - sbt test -J-Dmsgpack.universal-buffer=true
+  - ./sbt test
+  - ./sbt test -J-Dmsgpack.universal-buffer=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 
+sudo: false
+
 jdk:
   - openjdk7
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: scala
 
+cache:
+  directories:
+    - $HOME/.m2/repository/
+    - $HOME/.ivy2/cache/
+    - $HOME/.sbt/boot/
+
 sudo: false
 
 jdk:


### PR DESCRIPTION
A workaround with the TravisCI's default configuration, which causes JVM crash.

This PR will:
 - Use container-based TravisCi infrastructure (sudo: false)
 - Cache dependencies downloaded by mvn and sbt
 - Use local ./sbt script to test the availability of the sbt-launch.jar.