### PR TITLE
Add support for external buffer pools to packer

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -88,15 +88,15 @@ public class MessagePacker
     private final MessagePack.Config config;
 
     private MessageBufferOutput out;
+
     private MessageBuffer buffer;
-    private MessageBuffer strLenBuffer;
 
     private int position;
 
     /**
      * Total written byte size
      */
-    private long flushedBytes;
+    private long totalFlushBytes;
 
     /**
      * String encoder
@@ -119,7 +119,7 @@ public class MessagePacker
         this.config = checkNotNull(config, "config is null");
         this.out = checkNotNull(out, "MessageBufferOutput is null");
         this.position = 0;
-        this.flushedBytes = 0;
+        this.totalFlushBytes = 0;
     }
 
     /**
@@ -134,50 +134,32 @@ public class MessagePacker
         // Validate the argument
         MessageBufferOutput newOut = checkNotNull(out, "MessageBufferOutput is null");
 
-        // Reset the internal states
+        // Flush before reset
+        flush();
         MessageBufferOutput old = this.out;
         this.out = newOut;
-        this.position = 0;
-        this.flushedBytes = 0;
+
+        // Reset totalFlushBytes
+        this.totalFlushBytes = 0;
+
         return old;
     }
 
     public long getTotalWrittenBytes()
     {
-        return flushedBytes + position;
-    }
-
-    private void prepareEncoder()
-    {
-        if (encoder == null) {
-            this.encoder = MessagePack.UTF8.newEncoder().onMalformedInput(config.actionOnMalFormedInput).onUnmappableCharacter(config.actionOnMalFormedInput);
-        }
-    }
-
-    private void prepareBuffer()
-            throws IOException
-    {
-        if (buffer == null) {
-            buffer = out.next(config.packerBufferSize);
-        }
+        return totalFlushBytes + position;
     }
 
     public void flush()
             throws IOException
     {
-        if (buffer == null) {
-            return;
+        if (position > 0) {
+            out.writeBuffer(position);
+            buffer = null;
+            totalFlushBytes += position;
+            position = 0;
         }
-
-        if (position == buffer.size()) {
-            out.flush(buffer);
-        }
-        else {
-            out.flush(buffer.slice(0, position));
-        }
-        buffer = null;
-        flushedBytes += position;
-        position = 0;
+        out.flush();
     }
 
     public void close()
@@ -191,12 +173,18 @@ public class MessagePacker
         }
     }
 
-    private void ensureCapacity(int numBytesToWrite)
+    private void ensureCapacity(int mimimumSize)
             throws IOException
     {
-        if (buffer == null || position + numBytesToWrite >= buffer.size()) {
-            flush();
-            buffer = out.next(Math.max(config.packerBufferSize, numBytesToWrite));
+        if (buffer == null) {
+            buffer = out.next(mimimumSize);
+        }
+        else if (position + mimimumSize >= buffer.size()) {
+            out.writeBuffer(position);
+            buffer = null;
+            totalFlushBytes += position;
+            position = 0;
+            buffer = out.next(mimimumSize);
         }
     }
 
@@ -442,13 +430,43 @@ public class MessagePacker
         return this;
     }
 
-    private void packSmallString(String s)
+    private void packStringByGetBytes(String s)
             throws IOException
     {
         byte[] bytes = s.getBytes(MessagePack.UTF8);
         packRawStringHeader(bytes.length);
-        writePayload(bytes);
+        addPayload(bytes);
     }
+
+    private void prepareEncoder()
+    {
+        if (encoder == null) {
+            this.encoder = MessagePack.UTF8.newEncoder().onMalformedInput(config.actionOnMalFormedInput).onUnmappableCharacter(config.actionOnMalFormedInput);
+        }
+    }
+
+    private int encodeStringToBufferAt(int pos, String s)
+    {
+        prepareEncoder();
+        ByteBuffer bb = buffer.toByteBuffer(pos, buffer.size() - pos);
+        int startPosition = bb.position();
+        CharBuffer in = CharBuffer.wrap(s);
+        CoderResult cr = encoder.encode(in, bb, true);
+        if (cr.isError()) {
+            try {
+                cr.throwException();
+            }
+            catch (CharacterCodingException e) {
+                throw new MessageStringCodingException(e);
+            }
+        }
+        if (cr.isUnderflow() || cr.isOverflow()) {
+            return -1;
+        }
+        return bb.position() - startPosition;
+    }
+
+    private static final int UTF_8_MAX_CHAR_SIZE = 6;
 
     /**
      * Pack the input String in UTF-8 encoding
@@ -464,77 +482,76 @@ public class MessagePacker
             packRawStringHeader(0);
             return this;
         }
-
-        if (s.length() < config.packerSmallStringOptimizationThreshold) {
+        else if (s.length() < config.packerSmallStringOptimizationThreshold) {
             // Write the length and payload of small string to the buffer so that it avoids an extra flush of buffer
-            packSmallString(s);
+            packStringByGetBytes(s);
             return this;
         }
-
-        CharBuffer in = CharBuffer.wrap(s);
-        prepareEncoder();
-
-        flush();
-
-        prepareBuffer();
-        boolean isExtension = false;
-        ByteBuffer encodeBuffer = buffer.toByteBuffer(position, buffer.size() - position);
-        encoder.reset();
-        while (in.hasRemaining()) {
-            try {
-                CoderResult cr = encoder.encode(in, encodeBuffer, true);
-
-                // Input data is insufficient
-                if (cr.isUnderflow()) {
-                    cr = encoder.flush(encodeBuffer);
+        else if (s.length() < (1 << 8)) {
+            // ensure capacity for 2-byte raw string header + the maximum string size (+ 1 byte for falback code)
+            ensureCapacity(2 + s.length() * UTF_8_MAX_CHAR_SIZE + 1);
+            // keep 2-byte header region and write raw string
+            int written = encodeStringToBufferAt(position + 2, s);
+            if (written >= 0) {
+                if (written < (1 << 8)) {
+                    buffer.putByte(position++, STR8);
+                    buffer.putByte(position++, (byte) written);
+                    position += written;
                 }
-
-                // encodeBuffer is too small
-                if (cr.isOverflow()) {
-                    // Allocate a larger buffer
-                    int estimatedRemainingSize = Math.max(1, (int) (in.remaining() * encoder.averageBytesPerChar()));
-                    encodeBuffer.flip();
-                    ByteBuffer newBuffer = ByteBuffer.allocate(Math.max((int) (encodeBuffer.capacity() * 1.5), encodeBuffer.remaining() + estimatedRemainingSize));
-                    // Coy the current encodeBuffer contents to the new buffer
-                    newBuffer.put(encodeBuffer);
-                    encodeBuffer = newBuffer;
-                    isExtension = true;
-                    encoder.reset();
-                    continue;
-                }
-
-                if (cr.isError()) {
-                    if ((cr.isMalformed() && config.actionOnMalFormedInput == CodingErrorAction.REPORT) ||
-                            (cr.isUnmappable() && config.actionOnUnmappableCharacter == CodingErrorAction.REPORT)) {
-                        cr.throwException();
+                else {
+                    if (written >= (1 << 16)) {
+                        // this must not happen because s.length() is less than 2^8 and (2^8) * UTF_8_MAX_CHAR_SIZE is less than 2^16
+                        throw new IllegalArgumentException("Unexpected UTF-8 encoder state");
                     }
+                    // move 1 byte backward to expand 3-byte header region to 3 bytes
+                    buffer.putBytes(position + 3,
+                            buffer.getArray(), buffer.offset() + position + 2, written);
+                    // write 3-byte header header
+                    buffer.putByte(position++, STR16);
+                    buffer.putShort(position, (short) written);
+                    position += 2;
+                    position += written;
                 }
+                return this;
             }
-            catch (CharacterCodingException e) {
-                throw new MessageStringCodingException(e);
+        }
+        else if (s.length() < (1 << 16)) {
+            // ensure capacity for 3-byte raw string header + the maximum string size (+ 2 bytes for falback code)
+            ensureCapacity(3 + s.length() * UTF_8_MAX_CHAR_SIZE + 2);
+            // keep 3-byte header region and write raw string
+            int written = encodeStringToBufferAt(position + 3, s);
+            if (written >= 0) {
+                if (written < (1 << 16)) {
+                    buffer.putByte(position++, STR16);
+                    buffer.putShort(position, (short) written);
+                    position += 2;
+                    position += written;
+                }
+                else {
+                    if (written >= (1 << 32)) {
+                        // this must not happen because s.length() is less than 2^16 and (2^16) * UTF_8_MAX_CHAR_SIZE is less than 2^32
+                        throw new IllegalArgumentException("Unexpected UTF-8 encoder state");
+                    }
+                    // move 2 bytes backward to expand 3-byte header region to 5 bytes
+                    buffer.putBytes(position + 5,
+                            buffer.getArray(), buffer.offset() + position + 3, written);
+                    // write 3-byte header header
+                    buffer.putByte(position++, STR32);
+                    buffer.putInt(position, written);
+                    position += 4;
+                    position += written;
+                }
+                return this;
             }
         }
 
-        encodeBuffer.flip();
-        int strLen = encodeBuffer.remaining();
+        // Here doesn't use above optimized code for s.length() < (1 << 32) so that
+        // ensureCapacity is not called with an integer larger than (3 + ((1 << 16) * UTF_8_MAX_CHAR_SIZE) + 2).
+        // This makes it sure that MessageBufferOutput.next won't be called a size larger than
+        // 384KB, which is OK size to keep in memory.
 
-        // Preserve the current buffer
-        MessageBuffer tmpBuf = buffer;
-
-        // Switch the buffer to write the string length
-        if (strLenBuffer == null) {
-            strLenBuffer = MessageBuffer.newBuffer(5);
-        }
-        buffer = strLenBuffer;
-        position = 0;
-        // pack raw string header (string binary size)
-        packRawStringHeader(strLen);
-        flush(); // We need to dump the data here to MessageBufferOutput so that we can switch back to the original buffer
-
-        // Reset to the original buffer (or encodeBuffer if new buffer is allocated)
-        buffer = isExtension ? MessageBuffer.wrap(encodeBuffer) : tmpBuf;
-        // No need exists to write payload since the encoded string (payload) is already written to the buffer
-        position = strLen;
+        // fallback
+        packStringByGetBytes(s);
         return this;
     }
 
@@ -659,72 +676,82 @@ public class MessagePacker
         return this;
     }
 
-    public MessagePacker writePayload(ByteBuffer src)
-            throws IOException
-    {
-        int len = src.remaining();
-        if (len >= config.packerRawDataCopyingThreshold) {
-            // Use the source ByteBuffer directly to avoid memory copy
-
-            // First, flush the current buffer contents
-            flush();
-
-            // Wrap the input source as a MessageBuffer
-            MessageBuffer wrapped = MessageBuffer.wrap(src);
-            // Then, dump the source data to the output
-            out.flush(wrapped);
-            src.position(src.limit());
-            flushedBytes += len;
-        }
-        else {
-            // If the input source is small, simply copy the contents to the buffer
-            while (src.remaining() > 0) {
-                if (position >= buffer.size()) {
-                    flush();
-                }
-                prepareBuffer();
-                int writeLen = Math.min(buffer.size() - position, src.remaining());
-                buffer.putByteBuffer(position, src, writeLen);
-                position += writeLen;
-            }
-        }
-
-        return this;
-    }
-
+    /**
+     * Writes buffer to the output.
+     * This method is used with packRawStringHeader or packBinaryHeader.
+     *
+     * @param src the data to add
+     * @return this
+     * @throws IOException
+     */
     public MessagePacker writePayload(byte[] src)
             throws IOException
     {
         return writePayload(src, 0, src.length);
     }
 
+    /**
+     * Writes buffer to the output.
+     * This method is used with packRawStringHeader or packBinaryHeader.
+     *
+     * @param src the data to add
+     * @param off the start offset in the data
+     * @param len the number of bytes to add
+     * @return this
+     * @throws IOException
+     */
     public MessagePacker writePayload(byte[] src, int off, int len)
             throws IOException
     {
-        if (len >= config.packerRawDataCopyingThreshold) {
-            // Use the input array directory to avoid memory copy
-
-            // Flush the current buffer contents
-            flush();
-
-            // Wrap the input array as a MessageBuffer
-            MessageBuffer wrapped = MessageBuffer.wrap(src).slice(off, len);
-            // Dump the source data to the output
-            out.flush(wrapped);
-            flushedBytes += len;
+        if (buffer.size() - position < len || len > 8192) {
+            flush();  // call flush before write
+            out.write(src, off, len);
+            totalFlushBytes += len;
         }
         else {
-            int cursor = 0;
-            while (cursor < len) {
-                if (buffer != null && position >= buffer.size()) {
-                    flush();
-                }
-                prepareBuffer();
-                int writeLen = Math.min(buffer.size() - position, len - cursor);
-                buffer.putBytes(position, src, off + cursor, writeLen);
-                position += writeLen;
-                cursor += writeLen;
-            }
+            buffer.putBytes(position, src, off, len);
+            position += len;
+        }
+        return this;
+    }
+
+    /**
+     * Writes buffer to the output.
+     * Unlike writePayload method, addPayload method doesn't copy the source data. It means that the caller
+     * must not modify the data after calling this method.
+     *
+     * @param src the data to add
+     * @return this
+     * @throws IOException
+     */
+    public MessagePacker addPayload(byte[] src)
+            throws IOException
+    {
+        return addPayload(src, 0, src.length);
+    }
+
+    /**
+     * Writes buffer to the output.
+     * Unlike writePayload method, addPayload method doesn't copy the source data. It means that the caller
+     * must not modify the data after calling this method.
+     *
+     * @param src the data to add
+     * @param off the start offset in the data
+     * @param len the number of bytes to add
+     * @return this
+     * @throws IOException
+     */
+    public MessagePacker addPayload(byte[] src, int off, int len)
+            throws IOException
+    {
+        if (buffer.size() - position < len || len > 8192) {
+            flush();  // call flush before add
+            out.add(src, off, len);
+            totalFlushBytes += len;
+        }
+        else {
+            buffer.putBytes(position, src, off, len);
+            position += len;
         }
         return this;
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ChannelBufferOutput.java
@@ -32,14 +32,20 @@ public class ChannelBufferOutput
 
     public ChannelBufferOutput(WritableByteChannel channel)
     {
+        this(channel, 8192);
+    }
+
+    public ChannelBufferOutput(WritableByteChannel channel, int bufferSize)
+    {
         this.channel = checkNotNull(channel, "output channel is null");
+        this.buffer = MessageBuffer.newBuffer(bufferSize);
     }
 
     /**
-     * Reset channel. This method doesn't close the old resource.
+     * Reset channel. This method doesn't close the old channel.
      *
      * @param channel new channel
-     * @return the old resource
+     * @return the old channel
      */
     public WritableByteChannel reset(WritableByteChannel channel)
             throws IOException
@@ -50,21 +56,40 @@ public class ChannelBufferOutput
     }
 
     @Override
-    public MessageBuffer next(int bufferSize)
+    public MessageBuffer next(int mimimumSize)
             throws IOException
     {
-        if (buffer == null || buffer.size() != bufferSize) {
-            buffer = MessageBuffer.newBuffer(bufferSize);
+        if (buffer.size() < mimimumSize) {
+            buffer = MessageBuffer.newBuffer(mimimumSize);
         }
         return buffer;
     }
 
     @Override
-    public void flush(MessageBuffer buf)
+    public void writeBuffer(int length)
             throws IOException
     {
-        ByteBuffer bb = buf.toByteBuffer();
-        channel.write(bb);
+        ByteBuffer bb = buffer.toByteBuffer(0, length);
+        while (bb.hasRemaining()) {
+            channel.write(bb);
+        }
+    }
+
+    @Override
+    public void write(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        ByteBuffer bb = ByteBuffer.wrap(buffer, offset, length);
+        while (bb.hasRemaining()) {
+            channel.write(bb);
+        }
+    }
+
+    @Override
+    public void add(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        write(buffer, offset, length);
     }
 
     @Override
@@ -73,4 +98,9 @@ public class ChannelBufferOutput
     {
         channel.close();
     }
+
+    @Override
+    public void flush()
+            throws IOException
+    { }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -210,6 +210,11 @@ public class MessageBuffer
         return newMessageBuffer(array);
     }
 
+    public static MessageBuffer wrap(byte[] array, int offset, int length)
+    {
+        return newMessageBuffer(array).slice(offset, length);
+    }
+
     public static MessageBuffer wrap(ByteBuffer bb)
     {
         return newMessageBuffer(bb).slice(bb.position(), bb.remaining());

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferOutput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferOutput.java
@@ -17,30 +17,60 @@ package org.msgpack.core.buffer;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.Flushable;
 
 /**
- * Provides a sequence of MessageBuffers for packing the input data
+ * Provides a buffered output stream for packing objects
  */
 public interface MessageBufferOutput
-        extends Closeable
+        extends Closeable, Flushable
 {
     /**
-     * Retrieves the next buffer for writing message packed data
+     * Allocates the next buffer for writing message packed data.
+     * If the previously allocated buffer is not flushed yet, this next method should discard
+     * it without writing it.
      *
-     * @param bufferSize the buffer size to retrieve
+     * @param mimimumSize the mimium required buffer size to allocate
      * @return
      * @throws IOException
      */
-    public MessageBuffer next(int bufferSize)
+    public MessageBuffer next(int mimimumSize)
             throws IOException;
 
     /**
-     * Output the buffer contents. If you need to output a part of the
-     * buffer use {@link MessageBuffer#slice(int, int)}
+     * Flushes the previously allocated buffer.
+     * This method is not always called because next method also flushes previously allocated buffer.
+     * This method is called when write method is called or application wants to control the timing of flush.
      *
-     * @param buf
+     * @param length the size of buffer to flush
      * @throws IOException
      */
-    public void flush(MessageBuffer buf)
+    public void writeBuffer(int length)
+            throws IOException;
+
+    /**
+     * Writes an external payload data.
+     * This method should follow semantics of OutputStream.
+     *
+     * @param buffer the data to write
+     * @param offset the start offset in the data
+     * @param length the number of bytes to write
+     * @return
+     * @throws IOException
+     */
+    public void write(byte[] buffer, int offset, int length)
+            throws IOException;
+
+    /**
+     * Writes an external payload data.
+     * This buffer is given - this MessageBufferOutput owns the buffer and may modify contents of the buffer. Contents of this buffer won't be modified by the caller.
+     *
+     * @param buffer the data to add
+     * @param offset the start offset in the data
+     * @param length the number of bytes to add
+     * @return
+     * @throws IOException
+     */
+    public void add(byte[] buffer, int offset, int length)
             throws IOException;
 }

--- a/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
+++ b/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
@@ -153,11 +153,6 @@ public class MessagePackExample
                 .packArrayHeader(2)
                 .packString("xxx-xxxx")
                 .packString("yyy-yyyy");
-
-        // [Advanced] write data using ByteBuffer
-        ByteBuffer bb = ByteBuffer.wrap(new byte[] {'b', 'i', 'n', 'a', 'r', 'y', 'd', 'a', 't', 'a'});
-        packer.packBinaryHeader(bb.remaining());
-        packer.writePayload(bb);
     }
 
     /**

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackerTest.scala
@@ -283,12 +283,11 @@ class MessagePackerTest
 
   "support read-only buffer" taggedAs ("read-only") in {
     val payload = Array[Byte](1)
-    val buffer = ByteBuffer.wrap(payload).asReadOnlyBuffer()
     val out = new
         ByteArrayOutputStream()
     val packer = MessagePack.newDefaultPacker(out)
       .packBinaryHeader(1)
-      .writePayload(buffer)
+      .writePayload(payload)
       .close()
   }
 }

--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferOutputTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferOutputTest.scala
@@ -44,7 +44,7 @@ class MessageBufferOutputTest
   def writeIntToBuf(buf: MessageBufferOutput) = {
     val mb0 = buf.next(8)
     mb0.putInt(0, 42)
-    buf.flush(mb0)
+    buf.writeBuffer(4)
     buf.close
   }
 

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -183,8 +183,17 @@ public class MessagePackGenerator
         }
         else if (v instanceof ByteBuffer) {
             ByteBuffer bb = (ByteBuffer) v;
-            messagePacker.packBinaryHeader(bb.limit());
-            messagePacker.writePayload(bb);
+            int len = bb.remaining();
+            if (bb.hasArray()) {
+                messagePacker.packBinaryHeader(len);
+                messagePacker.writePayload(bb.array(), bb.arrayOffset(), len);
+            }
+            else {
+                byte[] data = new byte[len];
+                bb.get(data);
+                messagePacker.packBinaryHeader(len);
+                messagePacker.addPayload(data);
+            }
         }
         else if (v instanceof String) {
             messagePacker.packString((String) v);


### PR DESCRIPTION
This pull-request makes it possible that MessageBufferOutput implementations can allocate memory from external buffer pools such as Netty (netty-io) PooledByteBufAllocator or Jetty ByteBufferPool.
This pull-request consists with following changes:

* Improvements of MessageBufferOutput interface. The old `flush` method is divided into 3 methods: `writeBuffer`, `write`, `add`.
  * writeBuffer method writes the internal buffer. This lets MessageBufferOutput to know that the previously allocated buffer by `next()` is ready to release.
  * write and add method write external buffer which were NOT allocated by MessageBufferOutput.next. This lets MessageBufferOutput to tell that this buffer should not be returned to a memory pool. `write` method requires MessageBufferOutput to copy the contents of it immediately. `add` method moves ownership of the buffer to MessageBufferOutput so that it doesn't have to copy the buffer.
* Update of packString method to support the new API. This implementation tries to optimize performance by assuming that strings serialized using MessagePack are most likely ASCII-only or mostly ASCII. As long as this assumption is correct, number of flush calls to the final destination is reduced (buffering works better). If a lot of multi-byte UTF-8 sequences are given, this implementation causes one extra copy.
  * If source string is long (longer than 16K characters), this implementation immediately allocates a new buffer by calling String.getBytes. This is slightly inefficient because buffer is not reused. But In this case, this implementation can do another optimization that gives ownership of the new buffer to MessageBufferOutput.add method. Therefore MessageBufferOutput.add has chance to optimize by using zero-copy. Optimized MessageBufferOutput that takes advantage of it should be done in another pull-request. The reason of this overall design is to simplify the string encoding code.
