### PR TITLE
changing str8 format to be configurable (to use it or not), and injecting Config object to MessagePackFactory

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -214,9 +214,9 @@ public class MessagePack
     }
 
     /**
-     * Default configuration, which is visible only from classes in the core package.
+     * Default configuration
      */
-    static final Config DEFAULT_CONFIG = new ConfigBuilder().build();
+    public static final Config DEFAULT_CONFIG = new ConfigBuilder().build();
 
     /**
      * The prefix code set of MessagePack. See also https://github.com/msgpack/msgpack/blob/master/spec.md for details.

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -71,6 +71,12 @@ public class MessagePack
          * Note that this parameter is subject to change.
          */
         public final int packerSmallStringOptimizationThreshold;
+        /**
+         * disable str8 format when needed backward compatibility between
+         * different serializer versions.
+         * default true, which means no BC.
+         */
+        public final boolean supportStr8Format;
 
         public Config(
                 boolean readStringAsBinary,
@@ -82,7 +88,8 @@ public class MessagePack
                 int stringDecoderBufferSize,
                 int packerBufferSize,
                 int packerSmallStringOptimizationThreshold,
-                int packerRawDataCopyingThreshold)
+                int packerRawDataCopyingThreshold,
+                boolean supportStr8Format)
         {
             checkArgument(packerBufferSize > 0, "packer buffer size must be larger than 0: " + packerBufferSize);
             checkArgument(stringEncoderBufferSize > 0, "string encoder buffer size must be larger than 0: " + stringEncoderBufferSize);
@@ -98,6 +105,7 @@ public class MessagePack
             this.packerBufferSize = packerBufferSize;
             this.packerSmallStringOptimizationThreshold = packerSmallStringOptimizationThreshold;
             this.packerRawDataCopyingThreshold = packerRawDataCopyingThreshold;
+            this.supportStr8Format = supportStr8Format;
         }
     }
 
@@ -119,6 +127,8 @@ public class MessagePack
         private int packerSmallStringOptimizationThreshold = 512; // This parameter is subject to change
         private int packerRawDataCopyingThreshold = 512;
 
+        private boolean supportStr8Format = true;
+
         public Config build()
         {
             return new Config(
@@ -131,7 +141,8 @@ public class MessagePack
                     stringDecoderBufferSize,
                     packerBufferSize,
                     packerSmallStringOptimizationThreshold,
-                    packerRawDataCopyingThreshold
+                    packerRawDataCopyingThreshold,
+                    supportStr8Format
             );
         }
 
@@ -192,6 +203,12 @@ public class MessagePack
         public ConfigBuilder packerRawDataCopyingThreshold(int threshold)
         {
             this.packerRawDataCopyingThreshold = threshold;
+            return this;
+        }
+
+        public ConfigBuilder supportStr8Format(boolean support)
+        {
+            this.supportStr8Format = support;
             return this;
         }
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -647,7 +647,7 @@ public class MessagePacker
         if (len < (1 << 5)) {
             writeByte((byte) (FIXSTR_PREFIX | len));
         }
-        else if (len < (1 << 8)) {
+        else if (config.supportStr8Format && len < (1 << 8)) {
             writeByteAndByte(STR8, (byte) len);
         }
         else if (len < (1 << 16)) {

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.io.IOContext;
+import org.msgpack.core.MessagePack;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,11 +36,21 @@ public class MessagePackFactory
 {
     private static final long serialVersionUID = 2578263992015504347L;
 
+    private final MessagePack.Config config;
+
+    public MessagePackFactory() {
+        this(MessagePack.DEFAULT_CONFIG);
+    }
+
+    public MessagePackFactory(MessagePack.Config config) {
+        this.config = config;
+    }
+
     @Override
     public JsonGenerator createGenerator(OutputStream out, JsonEncoding enc)
             throws IOException
     {
-        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out);
+        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out, config);
     }
 
     @Override

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MessagePackGeneratorTest
@@ -378,5 +379,23 @@ public class MessagePackGeneratorTest
         assertEquals(1, unpacker.unpackArrayHeader());
         assertEquals(4, unpacker.unpackInt());
         assertEquals(5, unpacker.unpackLong());
+    }
+
+    @Test
+    public void testDisableStr8Support()
+            throws Exception
+    {
+        String str8LengthString = new String(new char[32]).replace("\0", "a");
+
+        // Test that produced value having str8 format
+        ObjectMapper defaultMapper = new ObjectMapper(new MessagePackFactory());
+        byte[] resultWithStr8Format = defaultMapper.writeValueAsBytes(str8LengthString);
+        assertEquals(resultWithStr8Format[0], MessagePack.Code.STR8);
+
+        // Test that produced value does not having str8 format
+        MessagePack.Config config = new MessagePack.ConfigBuilder().supportStr8Format(false).build();
+        ObjectMapper mapperWithConfig = new ObjectMapper(new MessagePackFactory(config));
+        byte[] resultWithoutStr8Format = mapperWithConfig.writeValueAsBytes(str8LengthString);
+        assertNotEquals(resultWithoutStr8Format[0], MessagePack.Code.STR8);
     }
 }


### PR DESCRIPTION
this pull request changes two things:
1. makes str8 format to be configurable (on or off), mainly for making migration to newer client easier (for people who aren't using latest 0.6 version, and want to be compatible with 0.7). See issue #313 
2. changing MessagePackFactory to have another c'tor which providing the ability of injecting configuration to MessagePacker, as today there's no way to do. For this change I had to drop ThreadLocal in MessagePackGenerator, but after checking carefully and doing concurrent tests, I believe there's no reason keeping it that way, and MessagePacker is not expensive to create. 