### PR TITLE
Make it possible to make ArrayBufferInput empty

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ArrayBufferInput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ArrayBufferInput.java
@@ -26,11 +26,17 @@ public class ArrayBufferInput
         implements MessageBufferInput
 {
     private MessageBuffer buffer;
-    private boolean isRead = false;
+    private boolean isEmpty;
 
     public ArrayBufferInput(MessageBuffer buf)
     {
-        this.buffer = checkNotNull(buf, "input buffer is null");
+        this.buffer = buf;
+        if (buf == null) {
+            isEmpty = true;
+        }
+        else {
+            isEmpty = false;
+        }
     }
 
     public ArrayBufferInput(byte[] arr)
@@ -54,10 +60,10 @@ public class ArrayBufferInput
         MessageBuffer old = this.buffer;
         this.buffer = buf;
         if (buf == null) {
-            this.isRead = true;
+            isEmpty = true;
         }
         else {
-            this.isRead = false;
+            isEmpty = false;
         }
         return old;
     }
@@ -76,10 +82,10 @@ public class ArrayBufferInput
     public MessageBuffer next()
             throws IOException
     {
-        if (isRead) {
+        if (isEmpty) {
             return null;
         }
-        isRead = true;
+        isEmpty = true;
         return buffer;
     }
 
@@ -88,6 +94,6 @@ public class ArrayBufferInput
             throws IOException
     {
         buffer = null;
-        isRead = true;
+        isEmpty = true;
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/ArrayBufferInput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/ArrayBufferInput.java
@@ -40,20 +40,25 @@ public class ArrayBufferInput
 
     public ArrayBufferInput(byte[] arr, int offset, int length)
     {
-        this(MessageBuffer.wrap(checkNotNull(arr, "input array is null")).slice(offset, length));
+        this(MessageBuffer.wrap(checkNotNull(arr, "input array is null"), offset, length));
     }
 
     /**
-     * Reset buffer. This method doesn't close the old resource.
+     * Reset buffer. This method returns the old buffer.
      *
-     * @param buf new buffer
-     * @return the old resource
+     * @param buf new buffer. This can be null to make this input empty.
+     * @return the old buffer.
      */
     public MessageBuffer reset(MessageBuffer buf)
     {
         MessageBuffer old = this.buffer;
         this.buffer = buf;
-        this.isRead = false;
+        if (buf == null) {
+            this.isRead = true;
+        }
+        else {
+            this.isRead = false;
+        }
         return old;
     }
 
@@ -64,7 +69,7 @@ public class ArrayBufferInput
 
     public void reset(byte[] arr, int offset, int len)
     {
-        reset(MessageBuffer.wrap(checkNotNull(arr, "input array is null")).slice(offset, len));
+        reset(MessageBuffer.wrap(checkNotNull(arr, "input array is null"), offset, len));
     }
 
     @Override
@@ -83,6 +88,6 @@ public class ArrayBufferInput
             throws IOException
     {
         buffer = null;
-        isRead = false;
+        isRead = true;
     }
 }


### PR DESCRIPTION
This change adds support to give null to ArrayBufferInput.reset method.
This lets applications control lifecycle of MessageBuffer (such as
releasing it to a buffer pool) before calling ArrayBufferInput.close().