### PR TITLE
Make constructors protected to ensure the single entry point

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
@@ -28,12 +28,12 @@ import java.util.List;
 public class MessageBufferPacker
         extends MessagePacker
 {
-    public MessageBufferPacker(MessagePack.PackerConfig config)
+    protected MessageBufferPacker(MessagePack.PackerConfig config)
     {
         this(new ArrayBufferOutput(), config);
     }
 
-    public MessageBufferPacker(ArrayBufferOutput out, MessagePack.PackerConfig config)
+    protected MessageBufferPacker(ArrayBufferOutput out, MessagePack.PackerConfig config)
     {
         super(out, config);
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -105,12 +105,13 @@ public class MessagePacker
     private CharsetEncoder encoder;
 
     /**
-     * Create an MessagePacker that outputs the packed data to the given {@link org.msgpack.core.buffer.MessageBufferOutput}
+     * Create an MessagePacker that outputs the packed data to the given {@link org.msgpack.core.buffer.MessageBufferOutput}.
+     * This method is available for subclasses to override. Use MessagePack.PackerConfig.newPacker method to instanciate this implementation.
      *
      * @param out MessageBufferOutput. Use {@link org.msgpack.core.buffer.OutputStreamBufferOutput}, {@link org.msgpack.core.buffer.ChannelBufferOutput} or
      * your own implementation of {@link org.msgpack.core.buffer.MessageBufferOutput} interface.
      */
-    public MessagePacker(MessageBufferOutput out, MessagePack.PackerConfig config)
+    protected MessagePacker(MessageBufferOutput out, MessagePack.PackerConfig config)
     {
         this.out = checkNotNull(out, "MessageBufferOutput is null");
         // We must copy the configuration parameters here since the config object is mutable

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -122,11 +122,12 @@ public class MessageUnpacker
     private CharBuffer decodeBuffer;
 
     /**
-     * Create an MessageUnpacker that reads data from the given MessageBufferInput
+     * Create an MessageUnpacker that reads data from the given MessageBufferInput.
+     * This method is available for subclasses to override. Use MessagePack.UnpackerConfig.newUnpacker method to instanciate this implementation.
      *
      * @param in
      */
-    public MessageUnpacker(MessageBufferInput in, MessagePack.UnpackerConfig config)
+    protected MessageUnpacker(MessageBufferInput in, MessagePack.UnpackerConfig config)
     {
         this.in = checkNotNull(in, "MessageBufferInput is null");
         // We need to copy the configuration parameters since the config object is mutable


### PR DESCRIPTION
Makes constructors of MessagePacker and MessageUnpacker protected so
that all users use factory methods of MessagePack interface. This
removes duplication of API and make it easy to understand.