### PR TITLE
Support method-chain syntax to create packer and unpacker with config

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -235,17 +235,9 @@ public class MessagePack
      */
     public static class PackerConfig
     {
-        /**
-         * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
-         * Note that this parameter is subject to change.
-         */
-        public int smallStringOptimizationThreshold = 512;
+        private int smallStringOptimizationThreshold = 512;
 
-        /**
-         * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
-         * packing the data.
-         */
-        public int bufferFlushThreshold = 8192;
+        private int bufferFlushThreshold = 8192;
 
         /**
          * Create a packer that outputs the packed data to a given output
@@ -289,6 +281,36 @@ public class MessagePack
         {
             return new MessageBufferPacker(this);
         }
+
+        /**
+         * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
+         * Note that this parameter is subject to change.
+         */
+        public PackerConfig setSmallStringOptimizationThreshold(int bytes)
+        {
+            this.smallStringOptimizationThreshold = bytes;
+            return this;
+        }
+
+        public int getSmallStringOptimizationThreshold()
+        {
+            return smallStringOptimizationThreshold;
+        }
+
+        /**
+         * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
+         * packing the data.
+         */
+        public PackerConfig setBufferFlushThreshold(int bytes)
+        {
+            this.bufferFlushThreshold = bytes;
+            return this;
+        }
+
+        public int getBufferFlushThreshold()
+        {
+            return bufferFlushThreshold;
+        }
     }
 
     /**
@@ -296,35 +318,20 @@ public class MessagePack
      */
     public static class UnpackerConfig
     {
-        /**
-         * Allow unpackBinaryHeader to read str format family  (default:true)
-         */
-        public boolean allowReadingStringAsBinary = true;
+        private boolean allowReadingStringAsBinary = true;
 
-        /**
-         * Allow unpackRawStringHeader and unpackString to read bin format family (default: true)
-         */
-        public boolean allowReadingBinaryAsString = true;
+        private boolean allowReadingBinaryAsString = true;
 
-        /**
-         * Action when encountered a malformed input
-         */
-        public CodingErrorAction actionOnMalformedString = CodingErrorAction.REPLACE;
+        private CodingErrorAction actionOnMalformedString = CodingErrorAction.REPLACE;
 
-        /**
-         * Action when an unmappable character is found
-         */
-        public CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
+        private CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
 
-        /**
-         * unpackString size limit. (default: Integer.MAX_VALUE)
-         */
-        public int stringSizeLimit = Integer.MAX_VALUE;
+        private int stringSizeLimit = Integer.MAX_VALUE;
 
         /**
          *
          */
-        public int stringDecoderBufferSize = 8192;
+        private int stringDecoderBufferSize = 8192;
 
         /**
          * Create an unpacker that reads the data from a given input
@@ -379,6 +386,90 @@ public class MessagePack
         public MessageUnpacker newUnpacker(byte[] contents, int offset, int length)
         {
             return newUnpacker(new ArrayBufferInput(contents, offset, length));
+        }
+
+        /**
+         * Allow unpackBinaryHeader to read str format family  (default:true)
+         */
+        public UnpackerConfig setAllowReadingStringAsBinary(boolean enable)
+        {
+            this.allowReadingStringAsBinary = enable;
+            return this;
+        }
+
+        public boolean getAllowReadingStringAsBinary()
+        {
+            return allowReadingStringAsBinary;
+        }
+
+        /**
+         * Allow unpackString and unpackRawStringHeader and unpackString to read bin format family (default: true)
+         */
+        public UnpackerConfig setAllowReadingBinaryAsString(boolean enable)
+        {
+            this.allowReadingBinaryAsString = enable;
+            return this;
+        }
+
+        public boolean getAllowReadingBinaryAsString()
+        {
+            return allowReadingBinaryAsString;
+        }
+
+        /**
+         * Action when encountered a malformed input (default: REPLACE)
+         */
+        public UnpackerConfig setActionOnMalformedString(CodingErrorAction action)
+        {
+            this.actionOnMalformedString = action;
+            return this;
+        }
+
+        public CodingErrorAction getActionOnMalformedString()
+        {
+            return actionOnMalformedString;
+        }
+
+        /**
+         * Action when an unmappable character is found (default: REPLACE)
+         */
+        public UnpackerConfig setActionOnUnmappableString(CodingErrorAction action)
+        {
+            this.actionOnUnmappableString = action;
+            return this;
+        }
+
+        public CodingErrorAction getActionOnUnmappableString()
+        {
+            return actionOnUnmappableString;
+        }
+
+        /**
+         * unpackString size limit. (default: Integer.MAX_VALUE)
+         */
+        public UnpackerConfig setStringSizeLimit(int bytes)
+        {
+            this.stringSizeLimit = bytes;
+            return this;
+        }
+
+        public int getStringSizeLimit()
+        {
+            return stringSizeLimit;
+        }
+
+        /**
+         *
+         */
+        public UnpackerConfig setStringDecoderBufferSize(int bytes)
+        {
+            this.stringDecoderBufferSize = bytes;
+            return this;
+        }
+
+        public int getStringDecoderBufferSize()
+        {
+            return stringDecoderBufferSize;
         }
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -114,8 +114,8 @@ public class MessagePacker
     {
         this.out = checkNotNull(out, "MessageBufferOutput is null");
         // We must copy the configuration parameters here since the config object is mutable
-        this.smallStringOptimizationThreshold = config.smallStringOptimizationThreshold;
-        this.bufferFlushThreshold = config.bufferFlushThreshold;
+        this.smallStringOptimizationThreshold = config.getSmallStringOptimizationThreshold();
+        this.bufferFlushThreshold = config.getBufferFlushThreshold();
         this.position = 0;
         this.totalFlushBytes = 0;
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -130,12 +130,12 @@ public class MessageUnpacker
     {
         this.in = checkNotNull(in, "MessageBufferInput is null");
         // We need to copy the configuration parameters since the config object is mutable
-        this.allowReadingStringAsBinary = config.allowReadingStringAsBinary;
-        this.allowReadingBinaryAsString = config.allowReadingBinaryAsString;
-        this.actionOnMalformedString = config.actionOnMalformedString;
-        this.actionOnUnmappableString = config.actionOnUnmappableString;
-        this.stringSizeLimit = config.stringSizeLimit;
-        this.stringDecoderBufferSize = config.stringDecoderBufferSize;
+        this.allowReadingStringAsBinary = config.getAllowReadingStringAsBinary();
+        this.allowReadingBinaryAsString = config.getAllowReadingBinaryAsString();
+        this.actionOnMalformedString = config.getActionOnMalformedString();
+        this.actionOnUnmappableString = config.getActionOnUnmappableString();
+        this.stringSizeLimit = config.getStringSizeLimit();
+        this.stringDecoderBufferSize = config.getStringDecoderBufferSize();
     }
 
     /**

--- a/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
+++ b/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
@@ -246,20 +246,19 @@ public class MessagePackExample
             throws IOException
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PackerConfig packerConfig = new PackerConfig();
-        packerConfig.smallStringOptimizationThreshold = 256; // String
-        MessagePacker packer = packerConfig.newPacker(out);
+        MessagePacker packer = new PackerConfig()
+            .setSmallStringOptimizationThreshold(256) // String
+            .newPacker(out);
 
         packer.packInt(10);
         packer.packBoolean(true);
         packer.close();
 
         // Unpack data
-        UnpackerConfig unpackerConfig = new UnpackerConfig();
-        unpackerConfig.stringDecoderBufferSize = 16 * 1024; // If your data contains many large strings (the default is 8k)
-
         byte[] packedData = out.toByteArray();
-        MessageUnpacker unpacker = unpackerConfig.newUnpacker(packedData);
+        MessageUnpacker unpacker = new UnpackerConfig()
+            .setStringDecoderBufferSize(16 * 1024) // If your data contains many large strings (the default is 8k)
+            .newUnpacker(packedData);
         int i = unpacker.unpackInt();  // 10
         boolean b = unpacker.unpackBoolean(); // true
         unpacker.close();

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -337,8 +337,9 @@ class MessagePackTest extends MessagePackSpec {
 
       // Report error on unmappable character
       val unpackerConfig = new UnpackerConfig()
-      unpackerConfig.actionOnMalformedString = CodingErrorAction.REPORT
-      unpackerConfig.actionOnUnmappableString = CodingErrorAction.REPORT
+      unpackerConfig
+          .setActionOnMalformedString(CodingErrorAction.REPORT)
+          .setActionOnUnmappableString(CodingErrorAction.REPORT)
 
       for (bytes <- Seq(unmappable)) {
         When("unpacking")


### PR DESCRIPTION
This change allows applications to use method-chain syntax to create packer and unpacker with config. For example,

```java
MessageUnpacker unpacker = new UnpackerConfig()
    .setStringDecoderBufferSize(16 * 1024)
    .setActionOnMalformedString(CodingErrorAction.REPORT)
    .setActionOnUnmappableString(CodingErrorAction.REPORT)
    .newUnpacker(packedData);
```

instead of

```java
UnpackerConfig unpackerConfig = new UnpackerConfig();
unpackerConfig.stringDecoderBufferSize = 16 * 1024;
unpackerConfig.actionOnMalformedString = CodingErrorAction.REPORT;
unpackerConfig.actionOnUnmappableString = CodingErrorAction.REPORT;
MessageUnpacker unpacker = unpackerConfig.newUnpacker(packedData);
```