### PR TITLE
Make buffer size of StreamBuffer{Input,Output} and ChannelBuffer{Input,Output} configurable

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -235,17 +235,9 @@ public class MessagePack
      */
     public static class PackerConfig
     {
-        /**
-         * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
-         * Note that this parameter is subject to change.
-         */
-        public int smallStringOptimizationThreshold = 512;
+        private int smallStringOptimizationThreshold = 512;
 
-        /**
-         * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
-         * packing the data.
-         */
-        public int bufferFlushThreshold = 8192;
+        private int bufferFlushThreshold = 8192;
 
         /**
          * Create a packer that outputs the packed data to a given output
@@ -289,6 +281,36 @@ public class MessagePack
         {
             return new MessageBufferPacker(this);
         }
+
+        /**
+         * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
+         * Note that this parameter is subject to change.
+         */
+        public PackerConfig setSmallStringOptimizationThreshold(int bytes)
+        {
+            this.smallStringOptimizationThreshold = bytes;
+            return this;
+        }
+
+        public int getSmallStringOptimizationThreshold()
+        {
+            return smallStringOptimizationThreshold;
+        }
+
+        /**
+         * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
+         * packing the data.
+         */
+        public PackerConfig setBufferFlushThreshold(int bytes)
+        {
+            this.bufferFlushThreshold = bytes;
+            return this;
+        }
+
+        public int getBufferFlushThreshold()
+        {
+            return bufferFlushThreshold;
+        }
     }
 
     /**
@@ -296,35 +318,20 @@ public class MessagePack
      */
     public static class UnpackerConfig
     {
-        /**
-         * Allow unpackBinaryHeader to read str format family  (default:true)
-         */
-        public boolean allowReadingStringAsBinary = true;
+        private boolean allowReadingStringAsBinary = true;
 
-        /**
-         * Allow unpackRawStringHeader and unpackString to read bin format family (default: true)
-         */
-        public boolean allowReadingBinaryAsString = true;
+        private boolean allowReadingBinaryAsString = true;
 
-        /**
-         * Action when encountered a malformed input
-         */
-        public CodingErrorAction actionOnMalformedString = CodingErrorAction.REPLACE;
+        private CodingErrorAction actionOnMalformedString = CodingErrorAction.REPLACE;
 
-        /**
-         * Action when an unmappable character is found
-         */
-        public CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
+        private CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
 
-        /**
-         * unpackString size limit. (default: Integer.MAX_VALUE)
-         */
-        public int stringSizeLimit = Integer.MAX_VALUE;
+        private int stringSizeLimit = Integer.MAX_VALUE;
 
         /**
          *
          */
-        public int stringDecoderBufferSize = 8192;
+        private int stringDecoderBufferSize = 8192;
 
         /**
          * Create an unpacker that reads the data from a given input
@@ -379,6 +386,90 @@ public class MessagePack
         public MessageUnpacker newUnpacker(byte[] contents, int offset, int length)
         {
             return newUnpacker(new ArrayBufferInput(contents, offset, length));
+        }
+
+        /**
+         * Allow unpackBinaryHeader to read str format family  (default:true)
+         */
+        public UnpackerConfig setAllowReadingStringAsBinary(boolean enable)
+        {
+            this.allowReadingStringAsBinary = enable;
+            return this;
+        }
+
+        public boolean getAllowReadingStringAsBinary()
+        {
+            return allowReadingStringAsBinary;
+        }
+
+        /**
+         * Allow unpackString and unpackRawStringHeader and unpackString to read bin format family (default: true)
+         */
+        public UnpackerConfig setAllowReadingBinaryAsString(boolean enable)
+        {
+            this.allowReadingBinaryAsString = enable;
+            return this;
+        }
+
+        public boolean getAllowReadingBinaryAsString()
+        {
+            return allowReadingBinaryAsString;
+        }
+
+        /**
+         * Action when encountered a malformed input (default: REPLACE)
+         */
+        public UnpackerConfig setActionOnMalformedString(CodingErrorAction action)
+        {
+            this.actionOnMalformedString = action;
+            return this;
+        }
+
+        public CodingErrorAction getActionOnMalformedString()
+        {
+            return actionOnMalformedString;
+        }
+
+        /**
+         * Action when an unmappable character is found (default: REPLACE)
+         */
+        public UnpackerConfig setActionOnUnmappableString(CodingErrorAction action)
+        {
+            this.actionOnUnmappableString = action;
+            return this;
+        }
+
+        public CodingErrorAction getActionOnUnmappableString()
+        {
+            return actionOnUnmappableString;
+        }
+
+        /**
+         * unpackString size limit. (default: Integer.MAX_VALUE)
+         */
+        public UnpackerConfig setStringSizeLimit(int bytes)
+        {
+            this.stringSizeLimit = bytes;
+            return this;
+        }
+
+        public int getStringSizeLimit()
+        {
+            return stringSizeLimit;
+        }
+
+        /**
+         *
+         */
+        public UnpackerConfig setStringDecoderBufferSize(int bytes)
+        {
+            this.stringDecoderBufferSize = bytes;
+            return this;
+        }
+
+        public int getStringDecoderBufferSize()
+        {
+            return stringDecoderBufferSize;
         }
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -239,6 +239,8 @@ public class MessagePack
 
         private int bufferFlushThreshold = 8192;
 
+        private int bufferSize = 8192;
+
         /**
          * Create a packer that outputs the packed data to a given output
          *
@@ -258,7 +260,7 @@ public class MessagePack
          */
         public MessagePacker newPacker(OutputStream out)
         {
-            return newPacker(new OutputStreamBufferOutput(out));
+            return newPacker(new OutputStreamBufferOutput(out, bufferSize));
         }
 
         /**
@@ -269,7 +271,7 @@ public class MessagePack
          */
         public MessagePacker newPacker(WritableByteChannel channel)
         {
-            return newPacker(new ChannelBufferOutput(channel));
+            return newPacker(new ChannelBufferOutput(channel, bufferSize));
         }
 
         /**
@@ -299,7 +301,7 @@ public class MessagePack
 
         /**
          * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
-         * packing the data.
+         * packing the data (default: 8192).
          */
         public PackerConfig setBufferFlushThreshold(int bytes)
         {
@@ -310,6 +312,21 @@ public class MessagePack
         public int getBufferFlushThreshold()
         {
             return bufferFlushThreshold;
+        }
+
+        /**
+         * When a packer is created with newPacker(OutputStream) or newPacker(WritableByteChannel), the stream will be
+         * buffered with this size of buffer (default: 8192).
+         */
+        public PackerConfig setBufferSize(int bytes)
+        {
+            this.bufferSize = bytes;
+            return this;
+        }
+
+        public int getBufferSize()
+        {
+            return bufferSize;
         }
     }
 
@@ -327,6 +344,8 @@ public class MessagePack
         private CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
 
         private int stringSizeLimit = Integer.MAX_VALUE;
+
+        private int bufferSize = 8192;
 
         /**
          *
@@ -352,7 +371,7 @@ public class MessagePack
          */
         public MessageUnpacker newUnpacker(InputStream in)
         {
-            return newUnpacker(new InputStreamBufferInput(in));
+            return newUnpacker(new InputStreamBufferInput(in, bufferSize));
         }
 
         /**
@@ -363,7 +382,7 @@ public class MessagePack
          */
         public MessageUnpacker newUnpacker(ReadableByteChannel channel)
         {
-            return newUnpacker(new ChannelBufferInput(channel));
+            return newUnpacker(new ChannelBufferInput(channel, bufferSize));
         }
 
         /**
@@ -389,7 +408,7 @@ public class MessagePack
         }
 
         /**
-         * Allow unpackBinaryHeader to read str format family  (default:true)
+         * Allow unpackBinaryHeader to read str format family  (default: true)
          */
         public UnpackerConfig setAllowReadingStringAsBinary(boolean enable)
         {
@@ -445,7 +464,7 @@ public class MessagePack
         }
 
         /**
-         * unpackString size limit. (default: Integer.MAX_VALUE)
+         * unpackString size limit (default: Integer.MAX_VALUE).
          */
         public UnpackerConfig setStringSizeLimit(int bytes)
         {
@@ -470,6 +489,21 @@ public class MessagePack
         public int getStringDecoderBufferSize()
         {
             return stringDecoderBufferSize;
+        }
+
+        /**
+         * When a packer is created with newUnpacker(OutputStream) or newUnpacker(WritableByteChannel), the stream will be
+         * buffered with this size of buffer (default: 8192).
+         */
+        public UnpackerConfig setBufferSize(int bytes)
+        {
+            this.bufferSize = bytes;
+            return this;
+        }
+
+        public int getBufferSize()
+        {
+            return bufferSize;
         }
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -114,8 +114,8 @@ public class MessagePacker
     {
         this.out = checkNotNull(out, "MessageBufferOutput is null");
         // We must copy the configuration parameters here since the config object is mutable
-        this.smallStringOptimizationThreshold = config.smallStringOptimizationThreshold;
-        this.bufferFlushThreshold = config.bufferFlushThreshold;
+        this.smallStringOptimizationThreshold = config.getSmallStringOptimizationThreshold();
+        this.bufferFlushThreshold = config.getBufferFlushThreshold();
         this.position = 0;
         this.totalFlushBytes = 0;
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -130,12 +130,12 @@ public class MessageUnpacker
     {
         this.in = checkNotNull(in, "MessageBufferInput is null");
         // We need to copy the configuration parameters since the config object is mutable
-        this.allowReadingStringAsBinary = config.allowReadingStringAsBinary;
-        this.allowReadingBinaryAsString = config.allowReadingBinaryAsString;
-        this.actionOnMalformedString = config.actionOnMalformedString;
-        this.actionOnUnmappableString = config.actionOnUnmappableString;
-        this.stringSizeLimit = config.stringSizeLimit;
-        this.stringDecoderBufferSize = config.stringDecoderBufferSize;
+        this.allowReadingStringAsBinary = config.getAllowReadingStringAsBinary();
+        this.allowReadingBinaryAsString = config.getAllowReadingBinaryAsString();
+        this.actionOnMalformedString = config.getActionOnMalformedString();
+        this.actionOnUnmappableString = config.getActionOnUnmappableString();
+        this.stringSizeLimit = config.getStringSizeLimit();
+        this.stringDecoderBufferSize = config.getStringDecoderBufferSize();
     }
 
     /**

--- a/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
+++ b/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
@@ -246,20 +246,19 @@ public class MessagePackExample
             throws IOException
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PackerConfig packerConfig = new PackerConfig();
-        packerConfig.smallStringOptimizationThreshold = 256; // String
-        MessagePacker packer = packerConfig.newPacker(out);
+        MessagePacker packer = new PackerConfig()
+            .setSmallStringOptimizationThreshold(256) // String
+            .newPacker(out);
 
         packer.packInt(10);
         packer.packBoolean(true);
         packer.close();
 
         // Unpack data
-        UnpackerConfig unpackerConfig = new UnpackerConfig();
-        unpackerConfig.stringDecoderBufferSize = 16 * 1024; // If your data contains many large strings (the default is 8k)
-
         byte[] packedData = out.toByteArray();
-        MessageUnpacker unpacker = unpackerConfig.newUnpacker(packedData);
+        MessageUnpacker unpacker = new UnpackerConfig()
+            .setStringDecoderBufferSize(16 * 1024) // If your data contains many large strings (the default is 8k)
+            .newUnpacker(packedData);
         int i = unpacker.unpackInt();  // 10
         boolean b = unpacker.unpackBoolean(); // true
         unpacker.close();

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -337,8 +337,9 @@ class MessagePackTest extends MessagePackSpec {
 
       // Report error on unmappable character
       val unpackerConfig = new UnpackerConfig()
-      unpackerConfig.actionOnMalformedString = CodingErrorAction.REPORT
-      unpackerConfig.actionOnUnmappableString = CodingErrorAction.REPORT
+      unpackerConfig
+          .setActionOnMalformedString(CodingErrorAction.REPORT)
+          .setActionOnUnmappableString(CodingErrorAction.REPORT)
 
       for (bytes <- Seq(unmappable)) {
         When("unpacking")


### PR DESCRIPTION
This change makes buffer size of InputStreamBufferInput, OutputStreamBufferOutput, and ChannelBuffer{Input,Output} configurable. Configurable buffer size is better because it is trade-off of performance and memory consumption.

This pull-request follows-up comment https://github.com/msgpack/msgpack-java/pull/310#issuecomment-169137363 at #310.
This pull-request assumes #322.