### PR TITLE
Make copy and reference clear at ValueFactory

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -494,11 +494,11 @@ public class MessageUnpacker
                 return ValueFactory.newFloat(unpackDouble());
             case STRING: {
                 int length = unpackRawStringHeader();
-                return ValueFactory.newString(readPayload(length));
+                return ValueFactory.newString(readPayload(length), true);
             }
             case BINARY: {
                 int length = unpackBinaryHeader();
-                return ValueFactory.newBinary(readPayload(length));
+                return ValueFactory.newBinary(readPayload(length), true);
             }
             case ARRAY: {
                 int size = unpackArrayHeader();
@@ -506,7 +506,7 @@ public class MessageUnpacker
                 for (int i = 0; i < size; i++) {
                     array[i] = unpackValue();
                 }
-                return ValueFactory.newArray(array);
+                return ValueFactory.newArray(array, true);
             }
             case MAP: {
                 int size = unpackMapHeader();
@@ -517,7 +517,7 @@ public class MessageUnpacker
                     kvs[i] = unpackValue();
                     i++;
                 }
-                return ValueFactory.newMap(kvs);
+                return ValueFactory.newMap(kvs, true);
             }
             case EXTENSION: {
                 ExtensionTypeHeader extHeader = unpackExtensionTypeHeader();

--- a/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java
@@ -87,12 +87,32 @@ public final class ValueFactory
 
     public static ImmutableBinaryValue newBinary(byte[] b)
     {
-        return new ImmutableBinaryValueImpl(b);
+        return newBinary(b, false);
+    }
+
+    public static ImmutableBinaryValue newBinary(byte[] b, boolean ref)
+    {
+        if (ref) {
+            return new ImmutableBinaryValueImpl(b);
+        }
+        else {
+            return new ImmutableBinaryValueImpl(Arrays.copyOf(b, b.length));
+        }
     }
 
     public static ImmutableBinaryValue newBinary(byte[] b, int off, int len)
     {
-        return new ImmutableBinaryValueImpl(Arrays.copyOfRange(b, off, len));
+        return newBinary(b, off, len, false);
+    }
+
+    public static ImmutableBinaryValue newBinary(byte[] b, int off, int len, boolean ref)
+    {
+        if (ref && off == 0 && len == b.length) {
+            return new ImmutableBinaryValueImpl(b);
+        }
+        else {
+            return new ImmutableBinaryValueImpl(Arrays.copyOfRange(b, off, len));
+        }
     }
 
     public static ImmutableStringValue newString(String s)
@@ -105,9 +125,29 @@ public final class ValueFactory
         return new ImmutableStringValueImpl(b);
     }
 
+    public static ImmutableStringValue newString(byte[] b, boolean ref)
+    {
+        if (ref) {
+            return new ImmutableStringValueImpl(b);
+        }
+        else {
+            return new ImmutableStringValueImpl(Arrays.copyOf(b, b.length));
+        }
+    }
+
     public static ImmutableStringValue newString(byte[] b, int off, int len)
     {
-        return new ImmutableStringValueImpl(Arrays.copyOfRange(b, off, len));
+        return newString(b, off, len, false);
+    }
+
+    public static ImmutableStringValue newString(byte[] b, int off, int len, boolean ref)
+    {
+        if (ref && off == 0 && len == b.length) {
+            return new ImmutableStringValueImpl(b);
+        }
+        else {
+            return new ImmutableStringValueImpl(Arrays.copyOfRange(b, off, len));
+        }
     }
 
     public static ImmutableArrayValue newArray(List<? extends Value> list)
@@ -124,7 +164,22 @@ public final class ValueFactory
         if (array.length == 0) {
             return ImmutableArrayValueImpl.empty();
         }
-        return new ImmutableArrayValueImpl(Arrays.copyOf(array, array.length));
+        else {
+            return new ImmutableArrayValueImpl(Arrays.copyOf(array, array.length));
+        }
+    }
+
+    public static ImmutableArrayValue newArray(Value[] array, boolean ref)
+    {
+        if (array.length == 0) {
+            return ImmutableArrayValueImpl.empty();
+        }
+        else if (ref) {
+            return new ImmutableArrayValueImpl(array);
+        }
+        else {
+            return new ImmutableArrayValueImpl(Arrays.copyOf(array, array.length));
+        }
     }
 
     public static ImmutableArrayValue emptyArray()
@@ -145,15 +200,30 @@ public final class ValueFactory
             kvs[index] = pair.getValue();
             index++;
         }
-        return newMap(kvs);
+        return new ImmutableMapValueImpl(kvs);
     }
 
-    public static ImmutableMapValue newMap(Value[] kvs)
+    public static ImmutableMapValue newMap(Value... kvs)
     {
         if (kvs.length == 0) {
             return ImmutableMapValueImpl.empty();
         }
-        return new ImmutableMapValueImpl(Arrays.copyOf(kvs, kvs.length));
+        else {
+            return new ImmutableMapValueImpl(Arrays.copyOf(kvs, kvs.length));
+        }
+    }
+
+    public static ImmutableMapValue newMap(Value[] kvs, boolean ref)
+    {
+        if (kvs.length == 0) {
+            return ImmutableMapValueImpl.empty();
+        }
+        else if (ref) {
+            return new ImmutableMapValueImpl(kvs);
+        }
+        else {
+            return new ImmutableMapValueImpl(Arrays.copyOf(kvs, kvs.length));
+        }
     }
 
     public static ImmutableMapValue emptyMap()

--- a/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java
@@ -90,9 +90,9 @@ public final class ValueFactory
         return newBinary(b, false);
     }
 
-    public static ImmutableBinaryValue newBinary(byte[] b, boolean ref)
+    public static ImmutableBinaryValue newBinary(byte[] b, boolean omitCopy)
     {
-        if (ref) {
+        if (omitCopy) {
             return new ImmutableBinaryValueImpl(b);
         }
         else {
@@ -105,9 +105,9 @@ public final class ValueFactory
         return newBinary(b, off, len, false);
     }
 
-    public static ImmutableBinaryValue newBinary(byte[] b, int off, int len, boolean ref)
+    public static ImmutableBinaryValue newBinary(byte[] b, int off, int len, boolean omitCopy)
     {
-        if (ref && off == 0 && len == b.length) {
+        if (omitCopy && off == 0 && len == b.length) {
             return new ImmutableBinaryValueImpl(b);
         }
         else {
@@ -125,9 +125,9 @@ public final class ValueFactory
         return new ImmutableStringValueImpl(b);
     }
 
-    public static ImmutableStringValue newString(byte[] b, boolean ref)
+    public static ImmutableStringValue newString(byte[] b, boolean omitCopy)
     {
-        if (ref) {
+        if (omitCopy) {
             return new ImmutableStringValueImpl(b);
         }
         else {
@@ -140,9 +140,9 @@ public final class ValueFactory
         return newString(b, off, len, false);
     }
 
-    public static ImmutableStringValue newString(byte[] b, int off, int len, boolean ref)
+    public static ImmutableStringValue newString(byte[] b, int off, int len, boolean omitCopy)
     {
-        if (ref && off == 0 && len == b.length) {
+        if (omitCopy && off == 0 && len == b.length) {
             return new ImmutableStringValueImpl(b);
         }
         else {
@@ -169,12 +169,12 @@ public final class ValueFactory
         }
     }
 
-    public static ImmutableArrayValue newArray(Value[] array, boolean ref)
+    public static ImmutableArrayValue newArray(Value[] array, boolean omitCopy)
     {
         if (array.length == 0) {
             return ImmutableArrayValueImpl.empty();
         }
-        else if (ref) {
+        else if (omitCopy) {
             return new ImmutableArrayValueImpl(array);
         }
         else {
@@ -213,12 +213,12 @@ public final class ValueFactory
         }
     }
 
-    public static ImmutableMapValue newMap(Value[] kvs, boolean ref)
+    public static ImmutableMapValue newMap(Value[] kvs, boolean omitCopy)
     {
         if (kvs.length == 0) {
             return ImmutableMapValueImpl.empty();
         }
-        else if (ref) {
+        else if (omitCopy) {
             return new ImmutableMapValueImpl(kvs);
         }
         else {


### PR DESCRIPTION
ValueFactory .newBinary, .newString, .newArray and .newMap take a
mutable argument. Some of them used them as a reference and some of them
copied them. This pull-request makes it clear that they copy the
argument by default and try to omit the copy if an extra argument is
set to true.

This change also includes:

* newMap(Value... kvs) method which was previously newMap(Value[] kvs)
* MessageUnpacker.unpackValue removes a duplicated copy of new byte[]
  (string and binary) or Value[] (array and map).