### PR TITLE
Support method-chain syntax to create packer and unpacker with immutable config

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -235,17 +235,9 @@ public class MessagePack
      */
     public static class PackerConfig
     {
-        /**
-         * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
-         * Note that this parameter is subject to change.
-         */
-        public int smallStringOptimizationThreshold = 512;
+        private int smallStringOptimizationThreshold = 512;
 
-        /**
-         * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
-         * packing the data.
-         */
-        public int bufferFlushThreshold = 8192;
+        private int bufferFlushThreshold = 8192;
 
         /**
          * Create a packer that outputs the packed data to a given output
@@ -289,6 +281,36 @@ public class MessagePack
         {
             return new MessageBufferPacker(this);
         }
+
+        /**
+         * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
+         * Note that this parameter is subject to change.
+         */
+        public PackerConfig setSmallStringOptimizationThreshold(int bytes)
+        {
+            this.smallStringOptimizationThreshold = bytes;
+            return this;
+        }
+
+        public int getSmallStringOptimizationThreshold()
+        {
+            return smallStringOptimizationThreshold;
+        }
+
+        /**
+         * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
+         * packing the data.
+         */
+        public PackerConfig setBufferFlushThreshold(int bytes)
+        {
+            this.bufferFlushThreshold = bytes;
+            return this;
+        }
+
+        public int getBufferFlushThreshold()
+        {
+            return bufferFlushThreshold;
+        }
     }
 
     /**
@@ -296,35 +318,20 @@ public class MessagePack
      */
     public static class UnpackerConfig
     {
-        /**
-         * Allow unpackBinaryHeader to read str format family  (default:true)
-         */
-        public boolean allowReadingStringAsBinary = true;
+        private boolean allowReadingStringAsBinary = true;
 
-        /**
-         * Allow unpackRawStringHeader and unpackString to read bin format family (default: true)
-         */
-        public boolean allowReadingBinaryAsString = true;
+        private boolean allowReadingBinaryAsString = true;
 
-        /**
-         * Action when encountered a malformed input
-         */
-        public CodingErrorAction actionOnMalformedString = CodingErrorAction.REPLACE;
+        private CodingErrorAction actionOnMalformedString = CodingErrorAction.REPLACE;
 
-        /**
-         * Action when an unmappable character is found
-         */
-        public CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
+        private CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
 
-        /**
-         * unpackString size limit. (default: Integer.MAX_VALUE)
-         */
-        public int stringSizeLimit = Integer.MAX_VALUE;
+        private int stringSizeLimit = Integer.MAX_VALUE;
 
         /**
          *
          */
-        public int stringDecoderBufferSize = 8192;
+        private int stringDecoderBufferSize = 8192;
 
         /**
          * Create an unpacker that reads the data from a given input
@@ -379,6 +386,90 @@ public class MessagePack
         public MessageUnpacker newUnpacker(byte[] contents, int offset, int length)
         {
             return newUnpacker(new ArrayBufferInput(contents, offset, length));
+        }
+
+        /**
+         * Allow unpackBinaryHeader to read str format family  (default:true)
+         */
+        public UnpackerConfig setAllowReadingStringAsBinary(boolean enable)
+        {
+            this.allowReadingStringAsBinary = enable;
+            return this;
+        }
+
+        public boolean getAllowReadingStringAsBinary()
+        {
+            return allowReadingStringAsBinary;
+        }
+
+        /**
+         * Allow unpackString and unpackRawStringHeader and unpackString to read bin format family (default: true)
+         */
+        public UnpackerConfig setAllowReadingBinaryAsString(boolean enable)
+        {
+            this.allowReadingBinaryAsString = enable;
+            return this;
+        }
+
+        public boolean getAllowReadingBinaryAsString()
+        {
+            return allowReadingBinaryAsString;
+        }
+
+        /**
+         * Action when encountered a malformed input (default: REPLACE)
+         */
+        public UnpackerConfig setActionOnMalformedString(CodingErrorAction action)
+        {
+            this.actionOnMalformedString = action;
+            return this;
+        }
+
+        public CodingErrorAction getActionOnMalformedString()
+        {
+            return actionOnMalformedString;
+        }
+
+        /**
+         * Action when an unmappable character is found (default: REPLACE)
+         */
+        public UnpackerConfig setActionOnUnmappableString(CodingErrorAction action)
+        {
+            this.actionOnUnmappableString = action;
+            return this;
+        }
+
+        public CodingErrorAction getActionOnUnmappableString()
+        {
+            return actionOnUnmappableString;
+        }
+
+        /**
+         * unpackString size limit. (default: Integer.MAX_VALUE)
+         */
+        public UnpackerConfig setStringSizeLimit(int bytes)
+        {
+            this.stringSizeLimit = bytes;
+            return this;
+        }
+
+        public int getStringSizeLimit()
+        {
+            return stringSizeLimit;
+        }
+
+        /**
+         *
+         */
+        public UnpackerConfig setStringDecoderBufferSize(int bytes)
+        {
+            this.stringDecoderBufferSize = bytes;
+            return this;
+        }
+
+        public int getStringDecoderBufferSize()
+        {
+            return stringDecoderBufferSize;
         }
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -380,9 +380,6 @@ public class MessagePack
 
         private int bufferSize = 8192;
 
-        /**
-         *
-         */
         private int stringDecoderBufferSize = 8192;
 
         public UnpackerConfig()
@@ -416,6 +413,7 @@ public class MessagePack
                     && this.actionOnMalformedString == o.actionOnMalformedString
                     && this.actionOnUnmappableString == o.actionOnUnmappableString
                     && this.stringSizeLimit == o.stringSizeLimit
+                    && this.stringDecoderBufferSize == o.stringDecoderBufferSize
                     && this.bufferSize == o.bufferSize;
         }
 

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -234,12 +234,41 @@ public class MessagePack
      * MessagePacker configuration.
      */
     public static class PackerConfig
+            implements Cloneable
     {
         private int smallStringOptimizationThreshold = 512;
 
         private int bufferFlushThreshold = 8192;
 
         private int bufferSize = 8192;
+
+        public PackerConfig()
+        { }
+
+        private PackerConfig(PackerConfig copy)
+        {
+            this.smallStringOptimizationThreshold = smallStringOptimizationThreshold;
+            this.bufferFlushThreshold = bufferFlushThreshold;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public PackerConfig clone()
+        {
+            return new PackerConfig(this);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof PackerConfig)) {
+                return false;
+            }
+            PackerConfig o = (PackerConfig) obj;
+            return this.smallStringOptimizationThreshold == o.smallStringOptimizationThreshold
+                    && this.bufferFlushThreshold == o.bufferFlushThreshold
+                    && this.bufferSize == o.bufferSize;
+        }
 
         /**
          * Create a packer that outputs the packed data to a given output
@@ -288,10 +317,11 @@ public class MessagePack
          * Use String.getBytes() for converting Java Strings that are smaller than this threshold into UTF8.
          * Note that this parameter is subject to change.
          */
-        public PackerConfig setSmallStringOptimizationThreshold(int bytes)
+        public PackerConfig withSmallStringOptimizationThreshold(int bytes)
         {
-            this.smallStringOptimizationThreshold = bytes;
-            return this;
+            PackerConfig copy = clone();
+            copy.smallStringOptimizationThreshold = bytes;
+            return copy;
         }
 
         public int getSmallStringOptimizationThreshold()
@@ -303,10 +333,11 @@ public class MessagePack
          * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
          * packing the data (default: 8192).
          */
-        public PackerConfig setBufferFlushThreshold(int bytes)
+        public PackerConfig withBufferFlushThreshold(int bytes)
         {
-            this.bufferFlushThreshold = bytes;
-            return this;
+            PackerConfig copy = clone();
+            copy.bufferFlushThreshold = bytes;
+            return copy;
         }
 
         public int getBufferFlushThreshold()
@@ -318,10 +349,11 @@ public class MessagePack
          * When a packer is created with newPacker(OutputStream) or newPacker(WritableByteChannel), the stream will be
          * buffered with this size of buffer (default: 8192).
          */
-        public PackerConfig setBufferSize(int bytes)
+        public PackerConfig withBufferSize(int bytes)
         {
-            this.bufferSize = bytes;
-            return this;
+            PackerConfig copy = clone();
+            copy.bufferSize = bytes;
+            return copy;
         }
 
         public int getBufferSize()
@@ -334,6 +366,7 @@ public class MessagePack
      * MessageUnpacker configuration.
      */
     public static class UnpackerConfig
+            implements Cloneable
     {
         private boolean allowReadingStringAsBinary = true;
 
@@ -351,6 +384,40 @@ public class MessagePack
          *
          */
         private int stringDecoderBufferSize = 8192;
+
+        public UnpackerConfig()
+        { }
+
+        private UnpackerConfig(UnpackerConfig copy)
+        {
+            this.allowReadingStringAsBinary = copy.allowReadingStringAsBinary;
+            this.allowReadingBinaryAsString = copy.allowReadingBinaryAsString;
+            this.actionOnMalformedString = copy.actionOnMalformedString;
+            this.actionOnUnmappableString = copy.actionOnUnmappableString;
+            this.stringSizeLimit = copy.stringSizeLimit;
+            this.bufferSize = copy.bufferSize;
+        }
+
+        @Override
+        public UnpackerConfig clone()
+        {
+            return new UnpackerConfig(this);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (!(obj instanceof UnpackerConfig)) {
+                return false;
+            }
+            UnpackerConfig o = (UnpackerConfig) obj;
+            return this.allowReadingStringAsBinary == o.allowReadingStringAsBinary
+                    && this.allowReadingBinaryAsString == o.allowReadingBinaryAsString
+                    && this.actionOnMalformedString == o.actionOnMalformedString
+                    && this.actionOnUnmappableString == o.actionOnUnmappableString
+                    && this.stringSizeLimit == o.stringSizeLimit
+                    && this.bufferSize == o.bufferSize;
+        }
 
         /**
          * Create an unpacker that reads the data from a given input
@@ -410,10 +477,11 @@ public class MessagePack
         /**
          * Allow unpackBinaryHeader to read str format family  (default: true)
          */
-        public UnpackerConfig setAllowReadingStringAsBinary(boolean enable)
+        public UnpackerConfig withAllowReadingStringAsBinary(boolean enable)
         {
-            this.allowReadingStringAsBinary = enable;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.allowReadingStringAsBinary = enable;
+            return copy;
         }
 
         public boolean getAllowReadingStringAsBinary()
@@ -424,10 +492,11 @@ public class MessagePack
         /**
          * Allow unpackString and unpackRawStringHeader and unpackString to read bin format family (default: true)
          */
-        public UnpackerConfig setAllowReadingBinaryAsString(boolean enable)
+        public UnpackerConfig withAllowReadingBinaryAsString(boolean enable)
         {
-            this.allowReadingBinaryAsString = enable;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.allowReadingBinaryAsString = enable;
+            return copy;
         }
 
         public boolean getAllowReadingBinaryAsString()
@@ -438,10 +507,11 @@ public class MessagePack
         /**
          * Action when encountered a malformed input (default: REPLACE)
          */
-        public UnpackerConfig setActionOnMalformedString(CodingErrorAction action)
+        public UnpackerConfig withActionOnMalformedString(CodingErrorAction action)
         {
-            this.actionOnMalformedString = action;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.actionOnMalformedString = action;
+            return copy;
         }
 
         public CodingErrorAction getActionOnMalformedString()
@@ -452,10 +522,11 @@ public class MessagePack
         /**
          * Action when an unmappable character is found (default: REPLACE)
          */
-        public UnpackerConfig setActionOnUnmappableString(CodingErrorAction action)
+        public UnpackerConfig withActionOnUnmappableString(CodingErrorAction action)
         {
-            this.actionOnUnmappableString = action;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.actionOnUnmappableString = action;
+            return copy;
         }
 
         public CodingErrorAction getActionOnUnmappableString()
@@ -466,10 +537,11 @@ public class MessagePack
         /**
          * unpackString size limit (default: Integer.MAX_VALUE).
          */
-        public UnpackerConfig setStringSizeLimit(int bytes)
+        public UnpackerConfig withStringSizeLimit(int bytes)
         {
-            this.stringSizeLimit = bytes;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.stringSizeLimit = bytes;
+            return copy;
         }
 
         public int getStringSizeLimit()
@@ -480,10 +552,11 @@ public class MessagePack
         /**
          *
          */
-        public UnpackerConfig setStringDecoderBufferSize(int bytes)
+        public UnpackerConfig withStringDecoderBufferSize(int bytes)
         {
-            this.stringDecoderBufferSize = bytes;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.stringDecoderBufferSize = bytes;
+            return copy;
         }
 
         public int getStringDecoderBufferSize()
@@ -495,10 +568,11 @@ public class MessagePack
          * When a packer is created with newUnpacker(OutputStream) or newUnpacker(WritableByteChannel), the stream will be
          * buffered with this size of buffer (default: 8192).
          */
-        public UnpackerConfig setBufferSize(int bytes)
+        public UnpackerConfig withBufferSize(int bytes)
         {
-            this.bufferSize = bytes;
-            return this;
+            UnpackerConfig copy = clone();
+            copy.bufferSize = bytes;
+            return copy;
         }
 
         public int getBufferSize()

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -239,6 +239,8 @@ public class MessagePack
 
         private int bufferFlushThreshold = 8192;
 
+        private int bufferSize = 8192;
+
         /**
          * Create a packer that outputs the packed data to a given output
          *
@@ -258,7 +260,7 @@ public class MessagePack
          */
         public MessagePacker newPacker(OutputStream out)
         {
-            return newPacker(new OutputStreamBufferOutput(out));
+            return newPacker(new OutputStreamBufferOutput(out, bufferSize));
         }
 
         /**
@@ -269,7 +271,7 @@ public class MessagePack
          */
         public MessagePacker newPacker(WritableByteChannel channel)
         {
-            return newPacker(new ChannelBufferOutput(channel));
+            return newPacker(new ChannelBufferOutput(channel, bufferSize));
         }
 
         /**
@@ -299,7 +301,7 @@ public class MessagePack
 
         /**
          * When the next payload size exceeds this threshold, MessagePacker will call MessageBufferOutput.flush() before
-         * packing the data.
+         * packing the data (default: 8192).
          */
         public PackerConfig setBufferFlushThreshold(int bytes)
         {
@@ -310,6 +312,21 @@ public class MessagePack
         public int getBufferFlushThreshold()
         {
             return bufferFlushThreshold;
+        }
+
+        /**
+         * When a packer is created with newPacker(OutputStream) or newPacker(WritableByteChannel), the stream will be
+         * buffered with this size of buffer (default: 8192).
+         */
+        public PackerConfig setBufferSize(int bytes)
+        {
+            this.bufferSize = bytes;
+            return this;
+        }
+
+        public int getBufferSize()
+        {
+            return bufferSize;
         }
     }
 
@@ -327,6 +344,8 @@ public class MessagePack
         private CodingErrorAction actionOnUnmappableString = CodingErrorAction.REPLACE;
 
         private int stringSizeLimit = Integer.MAX_VALUE;
+
+        private int bufferSize = 8192;
 
         /**
          *
@@ -352,7 +371,7 @@ public class MessagePack
          */
         public MessageUnpacker newUnpacker(InputStream in)
         {
-            return newUnpacker(new InputStreamBufferInput(in));
+            return newUnpacker(new InputStreamBufferInput(in, bufferSize));
         }
 
         /**
@@ -363,7 +382,7 @@ public class MessagePack
          */
         public MessageUnpacker newUnpacker(ReadableByteChannel channel)
         {
-            return newUnpacker(new ChannelBufferInput(channel));
+            return newUnpacker(new ChannelBufferInput(channel, bufferSize));
         }
 
         /**
@@ -389,7 +408,7 @@ public class MessagePack
         }
 
         /**
-         * Allow unpackBinaryHeader to read str format family  (default:true)
+         * Allow unpackBinaryHeader to read str format family  (default: true)
          */
         public UnpackerConfig setAllowReadingStringAsBinary(boolean enable)
         {
@@ -445,7 +464,7 @@ public class MessagePack
         }
 
         /**
-         * unpackString size limit. (default: Integer.MAX_VALUE)
+         * unpackString size limit (default: Integer.MAX_VALUE).
          */
         public UnpackerConfig setStringSizeLimit(int bytes)
         {
@@ -470,6 +489,21 @@ public class MessagePack
         public int getStringDecoderBufferSize()
         {
             return stringDecoderBufferSize;
+        }
+
+        /**
+         * When a packer is created with newUnpacker(OutputStream) or newUnpacker(WritableByteChannel), the stream will be
+         * buffered with this size of buffer (default: 8192).
+         */
+        public UnpackerConfig setBufferSize(int bytes)
+        {
+            this.bufferSize = bytes;
+            return this;
+        }
+
+        public int getBufferSize()
+        {
+            return bufferSize;
         }
     }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -114,8 +114,8 @@ public class MessagePacker
     {
         this.out = checkNotNull(out, "MessageBufferOutput is null");
         // We must copy the configuration parameters here since the config object is mutable
-        this.smallStringOptimizationThreshold = config.smallStringOptimizationThreshold;
-        this.bufferFlushThreshold = config.bufferFlushThreshold;
+        this.smallStringOptimizationThreshold = config.getSmallStringOptimizationThreshold();
+        this.bufferFlushThreshold = config.getBufferFlushThreshold();
         this.position = 0;
         this.totalFlushBytes = 0;
     }

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -113,7 +113,6 @@ public class MessagePacker
     public MessagePacker(MessageBufferOutput out, MessagePack.PackerConfig config)
     {
         this.out = checkNotNull(out, "MessageBufferOutput is null");
-        // We must copy the configuration parameters here since the config object is mutable
         this.smallStringOptimizationThreshold = config.getSmallStringOptimizationThreshold();
         this.bufferFlushThreshold = config.getBufferFlushThreshold();
         this.position = 0;

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -129,7 +129,6 @@ public class MessageUnpacker
     public MessageUnpacker(MessageBufferInput in, MessagePack.UnpackerConfig config)
     {
         this.in = checkNotNull(in, "MessageBufferInput is null");
-        // We need to copy the configuration parameters since the config object is mutable
         this.allowReadingStringAsBinary = config.getAllowReadingStringAsBinary();
         this.allowReadingBinaryAsString = config.getAllowReadingBinaryAsString();
         this.actionOnMalformedString = config.getActionOnMalformedString();

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -130,12 +130,12 @@ public class MessageUnpacker
     {
         this.in = checkNotNull(in, "MessageBufferInput is null");
         // We need to copy the configuration parameters since the config object is mutable
-        this.allowReadingStringAsBinary = config.allowReadingStringAsBinary;
-        this.allowReadingBinaryAsString = config.allowReadingBinaryAsString;
-        this.actionOnMalformedString = config.actionOnMalformedString;
-        this.actionOnUnmappableString = config.actionOnUnmappableString;
-        this.stringSizeLimit = config.stringSizeLimit;
-        this.stringDecoderBufferSize = config.stringDecoderBufferSize;
+        this.allowReadingStringAsBinary = config.getAllowReadingStringAsBinary();
+        this.allowReadingBinaryAsString = config.getAllowReadingBinaryAsString();
+        this.actionOnMalformedString = config.getActionOnMalformedString();
+        this.actionOnUnmappableString = config.getActionOnUnmappableString();
+        this.stringSizeLimit = config.getStringSizeLimit();
+        this.stringDecoderBufferSize = config.getStringDecoderBufferSize();
     }
 
     /**

--- a/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
+++ b/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
@@ -246,20 +246,19 @@ public class MessagePackExample
             throws IOException
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        PackerConfig packerConfig = new PackerConfig();
-        packerConfig.smallStringOptimizationThreshold = 256; // String
-        MessagePacker packer = packerConfig.newPacker(out);
+        MessagePacker packer = new PackerConfig()
+            .setSmallStringOptimizationThreshold(256) // String
+            .newPacker(out);
 
         packer.packInt(10);
         packer.packBoolean(true);
         packer.close();
 
         // Unpack data
-        UnpackerConfig unpackerConfig = new UnpackerConfig();
-        unpackerConfig.stringDecoderBufferSize = 16 * 1024; // If your data contains many large strings (the default is 8k)
-
         byte[] packedData = out.toByteArray();
-        MessageUnpacker unpacker = unpackerConfig.newUnpacker(packedData);
+        MessageUnpacker unpacker = new UnpackerConfig()
+            .setStringDecoderBufferSize(16 * 1024) // If your data contains many large strings (the default is 8k)
+            .newUnpacker(packedData);
         int i = unpacker.unpackInt();  // 10
         boolean b = unpacker.unpackBoolean(); // true
         unpacker.close();

--- a/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
+++ b/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java
@@ -247,7 +247,7 @@ public class MessagePackExample
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         MessagePacker packer = new PackerConfig()
-            .setSmallStringOptimizationThreshold(256) // String
+            .withSmallStringOptimizationThreshold(256) // String
             .newPacker(out);
 
         packer.packInt(10);
@@ -257,7 +257,7 @@ public class MessagePackExample
         // Unpack data
         byte[] packedData = out.toByteArray();
         MessageUnpacker unpacker = new UnpackerConfig()
-            .setStringDecoderBufferSize(16 * 1024) // If your data contains many large strings (the default is 8k)
+            .withStringDecoderBufferSize(16 * 1024) // If your data contains many large strings (the default is 8k)
             .newUnpacker(packedData);
         int i = unpacker.unpackInt();  // 10
         boolean b = unpacker.unpackBoolean(); // true

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -47,7 +47,6 @@ class MessagePackTest extends MessagePackSpec {
     }
   }
 
-
   "MessagePack" should {
     "detect fixint values" in {
 
@@ -497,5 +496,43 @@ class MessagePackTest extends MessagePackSpec {
       })
     }
 
+  }
+
+  "MessagePack.PackerConfig" should {
+    "be immutable" in {
+      val a = new MessagePack.PackerConfig()
+      val b = a.withBufferSize(64*1024)
+      a.equals(b) shouldBe false
+    }
+
+    "implement equals" in {
+      val a = new MessagePack.PackerConfig()
+      val b = new MessagePack.PackerConfig()
+      a.equals(b) shouldBe true
+      a.withBufferSize(64*1024).equals(b) shouldBe false
+      a.withSmallStringOptimizationThreshold(64).equals(b) shouldBe false
+      a.withBufferFlushThreshold(64*1024).equals(b) shouldBe false
+    }
+  }
+
+  "MessagePack.UnpackerConfig" should {
+    "be immutable" in {
+      val a = new MessagePack.UnpackerConfig()
+      val b = a.withBufferSize(64*1024)
+      a.equals(b) shouldBe false
+    }
+
+    "implement equals" in {
+      val a = new MessagePack.UnpackerConfig()
+      val b = new MessagePack.UnpackerConfig()
+      a.equals(b) shouldBe true
+      a.withBufferSize(64*1024).equals(b) shouldBe false
+      a.withAllowReadingStringAsBinary(false).equals(b) shouldBe false
+      a.withAllowReadingBinaryAsString(false).equals(b) shouldBe false
+      a.withActionOnMalformedString(CodingErrorAction.REPORT).equals(b) shouldBe false
+      a.withActionOnUnmappableString(CodingErrorAction.REPORT).equals(b) shouldBe false
+      a.withStringSizeLimit(32).equals(b) shouldBe false
+      a.withStringDecoderBufferSize(32).equals(b) shouldBe false
+    }
   }
 }

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -337,9 +337,8 @@ class MessagePackTest extends MessagePackSpec {
 
       // Report error on unmappable character
       val unpackerConfig = new UnpackerConfig()
-      unpackerConfig
-          .setActionOnMalformedString(CodingErrorAction.REPORT)
-          .setActionOnUnmappableString(CodingErrorAction.REPORT)
+          .withActionOnMalformedString(CodingErrorAction.REPORT)
+          .withActionOnUnmappableString(CodingErrorAction.REPORT)
 
       for (bytes <- Seq(unmappable)) {
         When("unpacking")

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -337,8 +337,9 @@ class MessagePackTest extends MessagePackSpec {
 
       // Report error on unmappable character
       val unpackerConfig = new UnpackerConfig()
-      unpackerConfig.actionOnMalformedString = CodingErrorAction.REPORT
-      unpackerConfig.actionOnUnmappableString = CodingErrorAction.REPORT
+      unpackerConfig
+          .setActionOnMalformedString(CodingErrorAction.REPORT)
+          .setActionOnUnmappableString(CodingErrorAction.REPORT)
 
       for (bytes <- Seq(unmappable)) {
         When("unpacking")


### PR DESCRIPTION
* This change allows applications to use method-chain syntax to create packer and unpacker with config. For example,

```java
MessageUnpacker unpacker = new UnpackerConfig()
    .withStringDecoderBufferSize(16 * 1024)
    .withActionOnMalformedString(CodingErrorAction.REPORT)
    .withActionOnUnmappableString(CodingErrorAction.REPORT)
    .newUnpacker(packedData);
```

* This change makes {Packer,Unpacker}Config immutable. This makes it safe to share a config object.

* This change makes buffer size of InputStreamBufferInput, OutputStreamBufferOutput, and ChannelBuffer{Input,Output} configurable. Configurable buffer size is better because it is trade-off of performance and memory consumption.