### PR TITLE
MessageBufferPacker.toByteArray flushes packer's internal buffer automatically

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
@@ -59,16 +59,37 @@ public class MessageBufferPacker
 
     public byte[] toByteArray()
     {
+        try {
+            flush();
+        }
+        catch (IOException ex) {
+            // IOException must not happen because underlaying ArrayBufferOutput never throws IOException
+            throw new RuntimeException(ex);
+        }
         return getArrayBufferOut().toByteArray();
     }
 
     public MessageBuffer toMessageBuffer()
     {
+        try {
+            flush();
+        }
+        catch (IOException ex) {
+            // IOException must not happen because underlaying ArrayBufferOutput never throws IOException
+            throw new RuntimeException(ex);
+        }
         return getArrayBufferOut().toMessageBuffer();
     }
 
     public List<MessageBuffer> toBufferList()
     {
+        try {
+            flush();
+        }
+        catch (IOException ex) {
+            // IOException must not happen because underlaying ArrayBufferOutput never throws IOException
+            throw new RuntimeException(ex);
+        }
         return getArrayBufferOut().toBufferList();
     }
 }

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessageBufferPackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessageBufferPackerTest.scala
@@ -1,0 +1,46 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.core
+
+import java.io.ByteArrayOutputStream
+import java.util.Arrays
+import org.msgpack.core.MessagePack.{UnpackerConfig, PackerConfig}
+import org.msgpack.core.buffer.OutputStreamBufferOutput
+import org.msgpack.value.Value
+import org.msgpack.value.ValueFactory._
+
+/**
+ *
+ */
+class MessageBufferPackerTest extends MessagePackSpec {
+  "MessageBufferPacker" should {
+    "be equivalent to ByteArrayOutputStream" in {
+      val packer1 = MessagePack.newDefaultBufferPacker()
+      packer1.packValue(newMap(Array[Value](
+              newString("a"), newInteger(1),
+              newString("b"), newString("s"))))
+
+      val stream = new ByteArrayOutputStream()
+      val packer2 = MessagePack.newDefaultPacker(stream)
+      packer2.packValue(newMap(Array[Value](
+              newString("a"), newInteger(1),
+              newString("b"), newString("s"))))
+      packer2.flush()
+
+      Arrays.equals(packer1.toByteArray(), stream.toByteArray()) shouldBe true
+    }
+  }
+}

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessageBufferPackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessageBufferPackerTest.scala
@@ -16,31 +16,26 @@
 package org.msgpack.core
 
 import java.io.ByteArrayOutputStream
-import java.util.Arrays
-import org.msgpack.core.MessagePack.{UnpackerConfig, PackerConfig}
-import org.msgpack.core.buffer.OutputStreamBufferOutput
+
 import org.msgpack.value.Value
 import org.msgpack.value.ValueFactory._
 
-/**
- *
- */
 class MessageBufferPackerTest extends MessagePackSpec {
   "MessageBufferPacker" should {
     "be equivalent to ByteArrayOutputStream" in {
-      val packer1 = MessagePack.newDefaultBufferPacker()
+      val packer1 = MessagePack.newDefaultBufferPacker
       packer1.packValue(newMap(Array[Value](
-              newString("a"), newInteger(1),
-              newString("b"), newString("s"))))
+        newString("a"), newInteger(1),
+        newString("b"), newString("s"))))
 
-      val stream = new ByteArrayOutputStream()
+      val stream = new ByteArrayOutputStream
       val packer2 = MessagePack.newDefaultPacker(stream)
       packer2.packValue(newMap(Array[Value](
-              newString("a"), newInteger(1),
-              newString("b"), newString("s"))))
-      packer2.flush()
+        newString("a"), newInteger(1),
+        newString("b"), newString("s"))))
+      packer2.flush
 
-      Arrays.equals(packer1.toByteArray(), stream.toByteArray()) shouldBe true
+      packer1.toByteArray shouldBe stream.toByteArray
     }
   }
 }


### PR DESCRIPTION
otherwise applications need to call flush() for sure, and we often miss it...
