### PR TITLE
changing str8 format to be configurable (to use it or not), and injecting Config object to MessagePackFactory

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -38,6 +38,12 @@ public class MessagePack
     public static final Charset UTF8 = Charset.forName("UTF-8");
 
     /**
+     * Default packer/unpacker configurations
+     */
+    public static final PackerConfig DEFAULT_PACKER_CONFIG = new PackerConfig();
+    public static final UnpackerConfig DEFAULT_UNPACKER_CONFIG = new UnpackerConfig();
+
+    /**
      * The prefix code set of MessagePack. See also https://github.com/msgpack/msgpack/blob/master/spec.md for details.
      */
     public static final class Code
@@ -138,7 +144,7 @@ public class MessagePack
      */
     public static MessagePacker newDefaultPacker(MessageBufferOutput out)
     {
-        return new PackerConfig().newPacker(out);
+        return DEFAULT_PACKER_CONFIG.newPacker(out);
     }
 
     /**
@@ -149,7 +155,7 @@ public class MessagePack
      */
     public static MessagePacker newDefaultPacker(OutputStream out)
     {
-        return new PackerConfig().newPacker(out);
+        return DEFAULT_PACKER_CONFIG.newPacker(out);
     }
 
     /**
@@ -160,7 +166,7 @@ public class MessagePack
      */
     public static MessagePacker newDefaultPacker(WritableByteChannel channel)
     {
-        return new PackerConfig().newPacker(channel);
+        return DEFAULT_PACKER_CONFIG.newPacker(channel);
     }
 
     /**
@@ -170,7 +176,7 @@ public class MessagePack
      */
     public static MessageBufferPacker newDefaultBufferPacker()
     {
-        return new PackerConfig().newBufferPacker();
+        return DEFAULT_PACKER_CONFIG.newBufferPacker();
     }
 
     /**
@@ -181,7 +187,7 @@ public class MessagePack
      */
     public static MessageUnpacker newDefaultUnpacker(MessageBufferInput in)
     {
-        return new UnpackerConfig().newUnpacker(in);
+        return DEFAULT_UNPACKER_CONFIG.newUnpacker(in);
     }
 
     /**
@@ -192,7 +198,7 @@ public class MessagePack
      */
     public static MessageUnpacker newDefaultUnpacker(InputStream in)
     {
-        return new UnpackerConfig().newUnpacker(in);
+        return DEFAULT_UNPACKER_CONFIG.newUnpacker(in);
     }
 
     /**
@@ -203,7 +209,7 @@ public class MessagePack
      */
     public static MessageUnpacker newDefaultUnpacker(ReadableByteChannel channel)
     {
-        return new UnpackerConfig().newUnpacker(channel);
+        return DEFAULT_UNPACKER_CONFIG.newUnpacker(channel);
     }
 
     /**
@@ -214,7 +220,7 @@ public class MessagePack
      */
     public static MessageUnpacker newDefaultUnpacker(byte[] contents)
     {
-        return new UnpackerConfig().newUnpacker(contents);
+        return DEFAULT_UNPACKER_CONFIG.newUnpacker(contents);
     }
 
     /**
@@ -227,7 +233,7 @@ public class MessagePack
      */
     public static MessageUnpacker newDefaultUnpacker(byte[] contents, int offset, int length)
     {
-        return new UnpackerConfig().newUnpacker(contents, offset, length);
+        return DEFAULT_UNPACKER_CONFIG.newUnpacker(contents, offset, length);
     }
 
     /**

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -258,6 +258,7 @@ public class MessagePack
             this.smallStringOptimizationThreshold = copy.smallStringOptimizationThreshold;
             this.bufferFlushThreshold = copy.bufferFlushThreshold;
             this.bufferSize = copy.bufferSize;
+            this.str8FormatSupport = copy.str8FormatSupport;
         }
 
         @Override
@@ -275,7 +276,8 @@ public class MessagePack
             PackerConfig o = (PackerConfig) obj;
             return this.smallStringOptimizationThreshold == o.smallStringOptimizationThreshold
                     && this.bufferFlushThreshold == o.bufferFlushThreshold
-                    && this.bufferSize == o.bufferSize;
+                    && this.bufferSize == o.bufferSize
+                    && this.str8FormatSupport == o.str8FormatSupport;
         }
 
         /**

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePack.java
@@ -248,6 +248,8 @@ public class MessagePack
 
         private int bufferSize = 8192;
 
+        private boolean str8FormatSupport = true;
+
         public PackerConfig()
         { }
 
@@ -365,6 +367,23 @@ public class MessagePack
         public int getBufferSize()
         {
             return bufferSize;
+        }
+
+        /**
+         * Disable str8 format when needed backward compatibility between
+         * different msgpack serializer versions.
+         * default true (str8 supported enabled)
+         */
+        public PackerConfig withStr8FormatSupport(boolean str8FormatSupport)
+        {
+            PackerConfig copy = clone();
+            copy.str8FormatSupport = str8FormatSupport;
+            return copy;
+        }
+
+        public boolean isStr8FormatSupport()
+        {
+            return str8FormatSupport;
         }
     }
 

--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -88,6 +88,8 @@ public class MessagePacker
 
     private final int bufferFlushThreshold;
 
+    private final boolean str8FormatSupport;
+
     protected MessageBufferOutput out;
 
     private MessageBuffer buffer;
@@ -116,6 +118,7 @@ public class MessagePacker
         this.out = checkNotNull(out, "MessageBufferOutput is null");
         this.smallStringOptimizationThreshold = config.getSmallStringOptimizationThreshold();
         this.bufferFlushThreshold = config.getBufferFlushThreshold();
+        this.str8FormatSupport = config.isStr8FormatSupport();
         this.position = 0;
         this.totalFlushBytes = 0;
     }
@@ -667,7 +670,7 @@ public class MessagePacker
         if (len < (1 << 5)) {
             writeByte((byte) (FIXSTR_PREFIX | len));
         }
-        else if (len < (1 << 8)) {
+        else if (str8FormatSupport && len < (1 << 8)) {
             writeByteAndByte(STR8, (byte) len);
         }
         else if (len < (1 << 16)) {

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -38,11 +38,13 @@ public class MessagePackFactory
 
     private final MessagePack.PackerConfig packerConfig;
 
-    public MessagePackFactory() {
+    public MessagePackFactory()
+    {
         this(MessagePack.DEFAULT_PACKER_CONFIG);
     }
 
-    public MessagePackFactory(final MessagePack.PackerConfig packerConfig) {
+    public MessagePackFactory(final MessagePack.PackerConfig packerConfig)
+    {
         this.packerConfig = packerConfig;
     }
 

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -43,7 +43,7 @@ public class MessagePackFactory
         this(MessagePack.DEFAULT_PACKER_CONFIG);
     }
 
-    public MessagePackFactory(final MessagePack.PackerConfig packerConfig)
+    public MessagePackFactory(MessagePack.PackerConfig packerConfig)
     {
         this.packerConfig = packerConfig;
     }

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.io.IOContext;
+import org.msgpack.core.MessagePack;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,11 +36,21 @@ public class MessagePackFactory
 {
     private static final long serialVersionUID = 2578263992015504347L;
 
+    private final MessagePack.PackerConfig packerConfig;
+
+    public MessagePackFactory() {
+        this(MessagePack.DEFAULT_PACKER_CONFIG);
+    }
+
+    public MessagePackFactory(final MessagePack.PackerConfig packerConfig) {
+        this.packerConfig = packerConfig;
+    }
+
     @Override
     public JsonGenerator createGenerator(OutputStream out, JsonEncoding enc)
             throws IOException
     {
-        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out);
+        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out, packerConfig);
     }
 
     @Override

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -95,7 +95,7 @@ public class MessagePackGenerator
         }
     }
 
-    public MessagePackGenerator(int features, ObjectCodec codec, OutputStream out, final MessagePack.PackerConfig packerConfig)
+    public MessagePackGenerator(int features, ObjectCodec codec, OutputStream out, MessagePack.PackerConfig packerConfig)
             throws IOException
     {
         super(features, codec);

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MessagePackGeneratorTest
@@ -434,5 +435,23 @@ public class MessagePackGeneratorTest
                 }
             }
         }
+    }
+
+    @Test
+    public void testDisableStr8Support()
+      throws Exception
+    {
+        String str8LengthString = new String(new char[32]).replace("\0", "a");
+
+        // Test that produced value having str8 format
+        ObjectMapper defaultMapper = new ObjectMapper(new MessagePackFactory());
+        byte[] resultWithStr8Format = defaultMapper.writeValueAsBytes(str8LengthString);
+        assertEquals(resultWithStr8Format[0], MessagePack.Code.STR8);
+
+        // Test that produced value does not having str8 format
+        MessagePack.PackerConfig config = new MessagePack.PackerConfig().withStr8FormatSupport(false);
+        ObjectMapper mapperWithConfig = new ObjectMapper(new MessagePackFactory(config));
+        byte[] resultWithoutStr8Format = mapperWithConfig.writeValueAsBytes(str8LengthString);
+        assertNotEquals(resultWithoutStr8Format[0], MessagePack.Code.STR8);
     }
 }


### PR DESCRIPTION
a new pull request after the discussion in the previous one (#314, #313).
this time the patch is made for msgpack 0.8
the changes are same as in the previous pull request (plus changes of the new configuration objects).