### PR TITLE
adding helper for serialization format of object mapper to be array

### DIFF
--- a/msgpack-jackson/README.md
+++ b/msgpack-jackson/README.md
@@ -83,3 +83,15 @@ Java
   // xs => [zero, 1, 2.0, null]
 ```
 
+### Serialization format
+
+By default, the serialization format is object, which means it includes the schema of the serialized entity (POJO).
+To serialize an entity without the schema, only as array, you can add the annotation `@JsonFormat(shape=JsonFormat.Shape.ARRAY)` to the entity definition.
+Also, it's possible to set the serialization format for the object mapper instance to be array by changing the annotation inspector of object mapper to `JsonArrayFormat`:
+
+```
+  ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
+  objectMapper.setAnnotationIntrospector(new JsonArrayFormat());
+```
+
+This format provides compatibility with msgpack-java 0.6.x serialization api.

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -12,8 +12,6 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
  * way.
  *
  * This also provides same behavior as msgpack-java 0.6.x serialization api.
- *
- * @author marenzo
  */
 public class JsonArrayFormat extends JacksonAnnotationIntrospector {
 

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -1,0 +1,33 @@
+package org.msgpack.jackson.dataformat;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
+
+/**
+ * Provides the ability of serializing POJOs without their schema.
+ * Similar to @JsonFormat annotation with JsonFormat.Shape.ARRAY, but in a programmatic
+ * way.
+ *
+ * This also provides same behavior as msgpack-java 0.6.x serialization api.
+ *
+ * @author marenzo
+ */
+public class JsonArrayFormat extends JacksonAnnotationIntrospector {
+
+  private final static JsonFormat.Value ARRAY_FORMAT = new JsonFormat.Value().withShape(ARRAY);
+
+  @Override
+  public JsonFormat.Value findFormat(Annotated ann)
+  {
+    // If the entity contains JsonFormat annotation, give it higher priority.
+    JsonFormat.Value precedenceFormat = super.findFormat(ann);
+    if (precedenceFormat != null) {
+      return precedenceFormat;
+    }
+
+    return ARRAY_FORMAT;
+  }
+}

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -15,7 +15,7 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
  */
 public class JsonArrayFormat extends JacksonAnnotationIntrospector
 {
-  private final static JsonFormat.Value ARRAY_FORMAT = new JsonFormat.Value().withShape(ARRAY);
+  private static final JsonFormat.Value ARRAY_FORMAT = new JsonFormat.Value().withShape(ARRAY);
 
   @Override
   public JsonFormat.Value findFormat(Annotated ann)

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -13,8 +13,8 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
  *
  * This also provides same behavior as msgpack-java 0.6.x serialization api.
  */
-public class JsonArrayFormat extends JacksonAnnotationIntrospector {
-
+public class JsonArrayFormat extends JacksonAnnotationIntrospector
+{
   private final static JsonFormat.Value ARRAY_FORMAT = new JsonFormat.Value().withShape(ARRAY);
 
   @Override

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
@@ -111,8 +111,8 @@ public class MessagePackDataformatForPojoTest
             throws IOException
     {
         ObjectMapper objectMapper = new ObjectMapper(factory); // to not affect shared objectMapper state
-        UsingCustomConstructorPojo orig = new UsingCustomConstructorPojo("komamitsu", 55);
         objectMapper.setAnnotationIntrospector(new JsonArrayFormat());
+        UsingCustomConstructorPojo orig = new UsingCustomConstructorPojo("komamitsu", 55);
         byte[] bytes = objectMapper.writeValueAsBytes(orig);
         String scheme = new String(bytes, Charset.forName("UTF-8"));
         assertThat(scheme, not(containsString("name")));

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
@@ -118,5 +118,6 @@ public class MessagePackDataformatForPojoTest
         assertThat(scheme, not(containsString("name")));
         UsingCustomConstructorPojo value = objectMapper.readValue(bytes, UsingCustomConstructorPojo.class);
         assertEquals("komamitsu", value.name);
+        assertEquals(55, value.age);
     }
 }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
@@ -20,14 +20,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.containsString;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
 
 public class MessagePackDataformatForPojoTest
         extends MessagePackDataformatTestBase
@@ -44,7 +43,7 @@ public class MessagePackDataformatForPojoTest
         assertEquals(normalPojo.l, value.l);
         assertEquals(normalPojo.f, value.f, 0.000001f);
         assertEquals(normalPojo.d, value.d, 0.000001f);
-        assertTrue(Arrays.equals(normalPojo.b, value.b));
+        assertArrayEquals(normalPojo.b, value.b);
         assertEquals(normalPojo.bi, value.bi);
         assertEquals(normalPojo.suit, Suit.HEART);
     }
@@ -56,7 +55,7 @@ public class MessagePackDataformatForPojoTest
         byte[] bytes = objectMapper.writeValueAsBytes(nestedListPojo);
         NestedListPojo value = objectMapper.readValue(bytes, NestedListPojo.class);
         assertEquals(nestedListPojo.s, value.s);
-        assertTrue(Arrays.equals(nestedListPojo.strs.toArray(), value.strs.toArray()));
+        assertArrayEquals(nestedListPojo.strs.toArray(), value.strs.toArray());
     }
 
     @Test
@@ -112,12 +111,13 @@ public class MessagePackDataformatForPojoTest
     {
         ObjectMapper objectMapper = new ObjectMapper(factory); // to not affect shared objectMapper state
         objectMapper.setAnnotationIntrospector(new JsonArrayFormat());
-        UsingCustomConstructorPojo orig = new UsingCustomConstructorPojo("komamitsu", 55);
-        byte[] bytes = objectMapper.writeValueAsBytes(orig);
+        byte[] bytes = objectMapper.writeValueAsBytes(complexPojo);
         String scheme = new String(bytes, Charset.forName("UTF-8"));
-        assertThat(scheme, not(containsString("name")));
-        UsingCustomConstructorPojo value = objectMapper.readValue(bytes, UsingCustomConstructorPojo.class);
+        assertThat(scheme, not(containsString("name"))); // validating schema doesn't contains keys, that's just array
+        ComplexPojo value = objectMapper.readValue(bytes, ComplexPojo.class);
         assertEquals("komamitsu", value.name);
-        assertEquals(55, value.age);
+        assertEquals(20, value.age);
+        assertArrayEquals(complexPojo.values.toArray(), value.values.toArray());
+        assertEquals(complexPojo.grades.get("math"), value.grades.get("math"));
     }
 }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
@@ -15,12 +15,18 @@
 //
 package org.msgpack.jackson.dataformat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.containsString;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class MessagePackDataformatForPojoTest
@@ -98,5 +104,19 @@ public class MessagePackDataformatForPojoTest
         byte[] bytes = objectMapper.writeValueAsBytes(orig);
         ChangingPropertyNamesPojo value = objectMapper.readValue(bytes, ChangingPropertyNamesPojo.class);
         assertEquals("komamitsu", value.getTheName());
+    }
+
+    @Test
+    public void testSerializationWithoutSchema()
+            throws IOException
+    {
+        ObjectMapper objectMapper = new ObjectMapper(factory); // to not affect shared objectMapper state
+        UsingCustomConstructorPojo orig = new UsingCustomConstructorPojo("komamitsu", 55);
+        objectMapper.setAnnotationIntrospector(new JsonArrayFormat());
+        byte[] bytes = objectMapper.writeValueAsBytes(orig);
+        String scheme = new String(bytes, Charset.forName("UTF-8"));
+        assertThat(scheme, not(containsString("name")));
+        UsingCustomConstructorPojo value = objectMapper.readValue(bytes, UsingCustomConstructorPojo.class);
+        assertEquals("komamitsu", value.name);
     }
 }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatTestBase.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatTestBase.java
@@ -32,6 +32,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Collections;
 
 public class MessagePackDataformatTestBase
 {
@@ -43,6 +45,7 @@ public class MessagePackDataformatTestBase
     protected NestedListPojo nestedListPojo;
     protected NestedListComplexPojo nestedListComplexPojo;
     protected TinyPojo tinyPojo;
+    protected ComplexPojo complexPojo;
 
     @Before
     public void setup()
@@ -65,14 +68,21 @@ public class MessagePackDataformatTestBase
 
         nestedListPojo = new NestedListPojo();
         nestedListPojo.s = "a string";
-        nestedListPojo.strs = Arrays.asList(new String[] {"string", "another string", "another string"});
+        nestedListPojo.strs = Arrays.asList("string", "another string", "another string");
 
         tinyPojo = new TinyPojo();
         tinyPojo.t = "t string";
+
         nestedListComplexPojo = new NestedListComplexPojo();
         nestedListComplexPojo.s = "a string";
         nestedListComplexPojo.foos = new ArrayList<TinyPojo>();
         nestedListComplexPojo.foos.add(tinyPojo);
+
+        complexPojo = new ComplexPojo();
+        complexPojo.name = "komamitsu";
+        complexPojo.age = 20;
+        complexPojo.grades = Collections.singletonMap("math", 97);
+        complexPojo.values = Arrays.asList("one", "two", "three");
     }
 
     @After
@@ -106,6 +116,14 @@ public class MessagePackDataformatTestBase
     {
         public String s;
         public List<String> strs;
+    }
+
+    public static class ComplexPojo
+    {
+        public String name;
+        public int age;
+        public List<String> values;
+        public Map<String, Integer> grades;
     }
 
     public static class TinyPojo


### PR DESCRIPTION
related to the tip that @komamitsu gave in #313 issue, about adding `@JsonFormat(shape=JsonFormat.Shape.ARRAY)` annotation to made a pojo being serialized as array. The issue with that is most of the times you have tons of pojo's around, and you can't enforce all of them to have this annotation, so I've made some global helper to enforce this serialization format on all of the objects serialized by object mapper.

this helper also was made because jackson doesn't provide any programmatic way to do such thing.