### PR TITLE
Ignoring unknown properties on de-serializing process

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -2,6 +2,7 @@ package org.msgpack.jackson.dataformat;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
@@ -17,6 +18,10 @@ public class JsonArrayFormat extends JacksonAnnotationIntrospector
 {
   private static final JsonFormat.Value ARRAY_FORMAT = new JsonFormat.Value().withShape(ARRAY);
 
+  /**
+   * Defines array format for serialized entities with ObjectMapper, without actually
+   * including the schema
+   */
   @Override
   public JsonFormat.Value findFormat(Annotated ann)
   {
@@ -27,5 +32,22 @@ public class JsonArrayFormat extends JacksonAnnotationIntrospector
     }
 
     return ARRAY_FORMAT;
+  }
+
+  /**
+   * Defines that unknown properties will be ignored, and won't fail the un-marshalling process.
+   * Happens in case of de-serialization of a payload that contains more properties than the actual
+   * value type
+   */
+  @Override
+  public Boolean findIgnoreUnknownProperties(AnnotatedClass ac)
+  {
+    // If the entity contains JsonIgnoreProperties annotation, give it higher priority.
+    final Boolean precedenceIgnoreUnknownProperties = super.findIgnoreUnknownProperties(ac);
+    if (precedenceIgnoreUnknownProperties != null) {
+      return precedenceIgnoreUnknownProperties;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
Related to #358

Having two entities, similar in fields except one may contain extra one, ObjectMapper will fail to de-serialize as it expects the payload to have exact same number of fields (properties) on the value type object.

Consider such case:
```
Pojo1 {
 field1;
 field2;
}

Pojo2 {
 field1;
}
```

Previous client could handle a case when de-serializing the payload of Pojo2 into Pojo1.

This is totally solvable by adding `@JsonIgnoreProperties` annotation, but since we already have `JsonArrayFormat` as helper for backward-compatibility, thought it also should be part of this utility.