### PR TITLE
Make MessageUnpacker.hasNext overridable

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -264,6 +264,12 @@ public class MessageUnpacker
     public boolean hasNext()
             throws IOException
     {
+        return ensureBuffer();
+    }
+
+    private boolean ensureBuffer()
+            throws IOException
+    {
         while (buffer.size() <= position) {
             MessageBuffer next = in.next();
             if (next == null) {
@@ -290,7 +296,7 @@ public class MessageUnpacker
             throws IOException
     {
         // makes sure that buffer has at leat 1 byte
-        if (!hasNext()) {
+        if (!ensureBuffer()) {
             throw new MessageInsufficientBufferException();
         }
         byte b = buffer.getByte(position);


### PR DESCRIPTION
In a case when a client knows the exact number of elements,
it can use an optimized overriden MessageUnpacker which always returns true