### PR TITLE
fix 'Unexpected UTF-8 encoder state' error at packString

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -555,7 +555,7 @@ public class MessagePacker
                     position += written;
                 }
                 else {
-                    if (written >= (1 << 32)) {
+                    if (written >= (1L << 32)) {  // this check does nothing because (1L << 32) is larger than Integer.MAX_VALUE
                         // this must not happen because s.length() is less than 2^16 and (2^16) * UTF_8_MAX_CHAR_SIZE is less than 2^32
                         throw new IllegalArgumentException("Unexpected UTF-8 encoder state");
                     }


### PR DESCRIPTION
A bug is that 1<<32 is 1 in Java. It must be 1L<<32.
A problem happens packString is called with a String that contains a string (longer than 1<<8 characters) and (shorter than 1<<16 characters) and (longer than 1<<16 bytes in UTF-8).
