### PR TITLE
Mimic SequenceInputStream interface more in SequenceMessageBufferInput

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/SequenceMessageBufferInput.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/SequenceMessageBufferInput.java
@@ -16,6 +16,8 @@
 package org.msgpack.core.buffer;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 
 import static org.msgpack.core.Preconditions.checkNotNull;
@@ -36,7 +38,15 @@ public class SequenceMessageBufferInput
             nextInput();
         }
         catch (IOException ignore) {
+            // never happens
         }
+    }
+
+    public SequenceMessageBufferInput(MessageBufferInput input1, MessageBufferInput input2)
+    {
+        this(Collections.enumeration(Arrays.asList(
+                checkNotNull(input1, "input1 is null"),
+                checkNotNull(input2, "input2 is null"))));
     }
 
     @Override


### PR DESCRIPTION
I commented as https://github.com/msgpack/msgpack-java/pull/387#pullrequestreview-1377376 but I changed my mind: I think it's ok to keep SequenceMessageBufferInput as a mimic of SequenceInputStream. We can create another class if necessary.

A reason is that behavior of `SequenceMessageBufferInput.close` (which is same with`SequenceInputStream.close`) is surprising, in my opinion. I expect that it closes input sequence without reading buffers. But they consume all of them. However, change of the behavior is also surprising because its behavior becomes inconsistent from SequenceInputStream.
