### PR TITLE
Fix #391: Add missing buffer null check

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -729,8 +729,9 @@ public class MessagePacker
     public MessagePacker writePayload(byte[] src, int off, int len)
             throws IOException
     {
-        if (buffer.size() - position < len || len > bufferFlushThreshold) {
+        if (buffer == null || buffer.size() - position < len || len > bufferFlushThreshold) {
             flush();  // call flush before write
+            // Directly write payload to the output without using the buffer
             out.write(src, off, len);
             totalFlushBytes += len;
         }
@@ -770,8 +771,9 @@ public class MessagePacker
     public MessagePacker addPayload(byte[] src, int off, int len)
             throws IOException
     {
-        if (buffer.size() - position < len || len > bufferFlushThreshold) {
+        if (buffer == null || buffer.size() - position < len || len > bufferFlushThreshold) {
             flush();  // call flush before add
+            // Directly add the payload without using the buffer
             out.add(src, off, len);
             totalFlushBytes += len;
         }

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackerTest.scala
@@ -317,4 +317,17 @@ class MessagePackerTest extends MessagePackSpec {
     val s = unpacker.unpackString()
     s shouldBe "small string"
   }
+
+  "write raw binary" taggedAs("raw-binary") in {
+    val packer = new MessagePack.PackerConfig().newBufferPacker()
+    val msg = Array[Byte](-127, -92, 116, 121, 112, 101, -92, 112, 105, 110, 103)
+    packer.writePayload(msg)
+  }
+
+  "append raw binary" taggedAs("append-raw-binary") in {
+    val packer = new MessagePack.PackerConfig().newBufferPacker()
+    val msg = Array[Byte](-127, -92, 116, 121, 112, 101, -92, 112, 105, 110, 103)
+    packer.addPayload(msg)
+  }
+
 }


### PR DESCRIPTION
If write/addPayload is used without any preceding packXXX methods, MessagePacker throws NPE #391