### PR TITLE
fix warning in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,8 @@ val buildSettings = findbugsSettings ++ jacoco.settings ++ osgiSettings ++ Seq[S
   jcheckStyleConfig := "facebook",
   
   // Run jcheckstyle both for main and test codes
-  compile <<= (compile in Compile) dependsOn (jcheckStyle in Compile),
-  compile <<= (compile in Test) dependsOn (jcheckStyle in Test)
+  (compile in Compile) := ((compile in Compile) dependsOn (jcheckStyle in Compile)).value,
+  (compile in Test) := ((compile in Test) dependsOn (jcheckStyle in Test)).value
 )
 
 val junitInterface = "com.novocode" % "junit-interface" % "0.11" % "test"


### PR DESCRIPTION
```
/home/travis/build/msgpack/msgpack-java/build.sbt:59: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
  compile <<= (compile in Compile) dependsOn (jcheckStyle in Compile),
          ^
/home/travis/build/msgpack/msgpack-java/build.sbt:60: warning: `<<=` operator is deprecated. Use `key := { x.value }` or `key ~= (old => { newValue })`.
See http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html
  compile <<= (compile in Test) dependsOn (jcheckStyle in Test)
          ^
```

https://travis-ci.org/msgpack/msgpack-java/jobs/179129836#L277