### PR TITLE
fix ambiguous overload in Java 9

### DIFF
--- a/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala
@@ -160,8 +160,8 @@ class MessageBufferTest
     "convert to ByteBuffer" in {
       for (t <- buffers) {
         val bb = t.sliceAsByteBuffer
-        bb.position shouldBe 0
-        bb.limit shouldBe 10
+        bb.position() shouldBe 0
+        bb.limit() shouldBe 10
         bb.capacity shouldBe 10
       }
     }


### PR DESCRIPTION
- http://download.java.net/java/jdk9/docs/api/java/nio/Buffer.html#limit-int-
- http://download.java.net/java/jdk9/docs/api/java/nio/ByteBuffer.html#position-int-

```
[error] /home/travis/build/xuwei-k/msgpack-java/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala:163: ambiguous reference to overloaded definition,
[error] both method position in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method position in class Buffer of type ()Int
[error] match expected type ?
[error]         bb.position shouldBe 0
[error]            ^
[error] /home/travis/build/xuwei-k/msgpack-java/msgpack-core/src/test/scala/org/msgpack/core/buffer/MessageBufferTest.scala:164: ambiguous reference to overloaded definition,
[error] both method limit in class ByteBuffer of type (x$1: Int)java.nio.ByteBuffer
[error] and  method limit in class Buffer of type ()Int
[error] match expected type ?
[error]         bb.limit shouldBe 10
[error]            ^
[error] two errors found
```