### PR TITLE
Add MessageBufferPacker#getSize()

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
@@ -123,4 +123,12 @@ public class MessageBufferPacker
         }
         return getArrayBufferOut().toBufferList();
     }
+
+    /**
+     * @return size of written data
+     */
+    public int getSize()
+    {
+        return getArrayBufferOut().getSize();
+    }
 }


### PR DESCRIPTION
Without this method it seems that the only option to know size of data written to MessageBufferPacker prior to accessing it is to use toByteArray().length (too much copying) or toMessageBuffer().size() - still copying in case of much data.