### PR TITLE
remove oraclejdk7 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ sudo: false
 
 jdk:
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 branches:


### PR DESCRIPTION
travis-ci no longer support oraclejdk7

- https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
- http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html