### PR TITLE
"test-only" does not work since sbt 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Here is a list of sbt commands for daily development:
 > ~compile                                 # Compile source codes
 > ~test:compile                            # Compile both source and test codes
 > ~test                                    # Run tests upon source code change
-> ~test-only *MessagePackTest              # Run tests in the specified class
-> ~test-only *MessagePackTest -- -n prim   # Run the test tagged as "prim"
+> ~testOnly *MessagePackTest               # Run tests in the specified class
+> ~testOnly *MessagePackTest -- -n prim    # Run the test tagged as "prim"
 > project msgpack-core                     # Focus on a specific project
 > package                                  # Create a jar file in the target folder of each project
 > findbugs                                 # Produce findbugs report in target/findbugs


### PR DESCRIPTION
https://github.com/sbt/sbt/blob/v1.0.4/notes/1.0.0.markdown

> Drops sbt 0.12 style hyphen-separated key names