### PR TITLE
use JavaConverters instead of JavaConversions

### DIFF
--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -562,8 +562,8 @@ class MessagePackTest extends MessagePackSpec {
         }, { unpacker =>
           val v = new Variable()
           unpacker.unpackValue(v)
-          import scala.collection.JavaConversions._
-          v.asArrayValue()
+          import scala.collection.JavaConverters._
+          v.asArrayValue().asScala
             .map { m =>
               val mv  = m.asMapValue()
               val kvs = mv.getKeyValueArray

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessageUnpackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessageUnpackerTest.scala
@@ -23,7 +23,7 @@ import org.msgpack.core.buffer._
 import org.msgpack.value.ValueType
 import xerial.core.io.IOUtil._
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.util.Random
 
 object MessageUnpackerTest {
@@ -229,10 +229,10 @@ class MessageUnpackerTest extends MessagePackSpec {
       position += length
     }
     val builder = Seq.newBuilder[MessageUnpacker]
-    builder += MessagePack.newDefaultUnpacker(new SequenceMessageBufferInput(Collections.enumeration(seqBytes.result())))
-    builder += MessagePack.newDefaultUnpacker(new SequenceMessageBufferInput(Collections.enumeration(seqByteBuffers.result())))
+    builder += MessagePack.newDefaultUnpacker(new SequenceMessageBufferInput(Collections.enumeration(seqBytes.result().asJava)))
+    builder += MessagePack.newDefaultUnpacker(new SequenceMessageBufferInput(Collections.enumeration(seqByteBuffers.result().asJava)))
     if (!universal) {
-      builder += MessagePack.newDefaultUnpacker(new SequenceMessageBufferInput(Collections.enumeration(seqDirectBuffers.result())))
+      builder += MessagePack.newDefaultUnpacker(new SequenceMessageBufferInput(Collections.enumeration(seqDirectBuffers.result().asJava)))
     }
 
     builder.result()


### PR DESCRIPTION
JavaConversions is deprecated since Scala 2.12

https://github.com/scala/scala/blob/v2.12.4/src/library/scala/collection/JavaConversions.scala#L59