### PR TITLE
add SafeVarargs annotation

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java
@@ -228,6 +228,7 @@ public final class ValueFactory
         return ImmutableMapValueImpl.empty();
     }
 
+    @SafeVarargs
     public static MapValue newMap(Map.Entry<? extends Value, ? extends Value>... pairs)
     {
         Value[] kvs = new Value[pairs.length * 2];


### PR DESCRIPTION
suppress following warning

https://travis-ci.org/msgpack/msgpack-java/jobs/337228566#L522

```
[warn] /home/travis/build/msgpack/msgpack-java/msgpack-core/src/main/java/org/msgpack/value/ValueFactory.java:231:1: Possible heap pollution from parameterized vararg type java.util.Map.Entry<? extends org.msgpack.value.Value,? extends org.msgpack.value.Value>
[warn]     public static MapValue newMap(Map.Entry<? extends Value, ? extends Value>... pairs)
```