### PR TITLE
Update jackson-databind 2.7.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ lazy val msgpackJackson =
         "org.msgpack.jackson.dataformat"
       ),
       libraryDependencies ++= Seq(
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.1",
+        "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.9.1",
         junitInterface,
         "org.apache.commons" % "commons-math3" % "3.6.1" % "test"
       ),


### PR DESCRIPTION
to address https://github.com/FasterXML/jackson-databind/issues/1599

With 2.8.10, it degrades the serialization performance of
jackson-dataformat-msgpack down to 62%. So we'd better still use 2.7 for now.

Fix https://github.com/msgpack/msgpack-java/issues/463