### PR TITLE
avoid creating MessageBuffer needlessly, convert degenerate switch to if

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -607,11 +607,11 @@ public class MessageUnpacker
             case BOOLEAN:
                 return ValueFactory.newBoolean(unpackBoolean());
             case INTEGER:
-                switch (mf) {
-                    case UINT64:
-                        return ValueFactory.newInteger(unpackBigInteger());
-                    default:
-                        return ValueFactory.newInteger(unpackLong());
+                if (mf == MessageFormat.UINT64) {
+                    return ValueFactory.newInteger(unpackBigInteger());
+                }
+                else {
+                    return ValueFactory.newInteger(unpackLong());
                 }
             case FLOAT:
                 return ValueFactory.newFloat(unpackDouble());

--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -1597,7 +1597,20 @@ public class MessageUnpacker
     public void readPayload(byte[] dst, int off, int len)
             throws IOException
     {
-        readPayload(MessageBuffer.wrap(dst), off, len);
+        while (true) {
+            int bufferRemaining = buffer.size() - position;
+            if (bufferRemaining >= len) {
+                buffer.getBytes(position, dst, off, len);
+                position += len;
+                return;
+            }
+            buffer.getBytes(position, dst, off, bufferRemaining);
+            off += bufferRemaining;
+            len -= bufferRemaining;
+            position += bufferRemaining;
+
+            nextBuffer();
+        }
     }
 
     /**


### PR DESCRIPTION
Avoid creating MessageBuffer just as a wrapper, MessageBuffer.getBytes() is there for that.

(previously #477)