### PR TITLE
Fix strings of integers over 2^63-1 gets encoded as float64 instead of uint64

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -442,22 +442,6 @@ public class MessagePackGenerator
         // If users can use other MessagePackGenerator#writeNumber APIs that accept
         // proper numeric types not String, it's better to use the other APIs instead.
         try {
-            long l = Long.parseLong(encodedValue);
-            addValueToStackTop(l);
-            return;
-        }
-        catch (NumberFormatException e) {
-        }
-
-        try {
-            double d = Double.parseDouble(encodedValue);
-            addValueToStackTop(d);
-            return;
-        }
-        catch (NumberFormatException e) {
-        }
-
-        try {
             BigInteger bi = new BigInteger(encodedValue);
             addValueToStackTop(bi);
             return;

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -881,7 +881,7 @@ public class MessagePackGeneratorTest
 
         BigInteger bi = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
         assertThat(
-            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(bi)).unpackDouble(),
-                is(bi.doubleValue()));
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(bi)).unpackBigInteger(),
+                is(bi));
     }
 }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -854,7 +854,7 @@ public class MessagePackGeneratorTest
         objectMapper.registerModule(
                 new SimpleModule().addSerializer(BigDecimal.class, new BigDecimalSerializerStoringAsString()));
 
-        BigDecimal bd = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+        BigDecimal bd = BigDecimal.valueOf(Double.MAX_VALUE);
         assertThat(
             MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(bd)).unpackDouble(),
                 is(bd.doubleValue()));


### PR DESCRIPTION
Closes #487 