### PR TITLE
Fixed the Javadoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ supports all of the message pack types, including [extension format](https://git
 ## Quick Start
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.msgpack/msgpack-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.msgpack/msgpack-core/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/org.msgpack/msgpack-core/badge.svg)](http://www.javadoc.io/doc/org.msgpack/msgpack-core)
+[![Javadoc](https://javadoc-badge.appspot.com/org.msgpack/msgpack-core.svg?label=javadoc.io)](http://www.javadoc.io/doc/org.msgpack/msgpack-core)
 
 For Maven users:
 ```


### PR DESCRIPTION
I hope I'm not overstepping. I saw that the Javadoc badge wasn't working so I fixed the url for it. 