### PR TITLE
Fix issue:508

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 
+# With xenial, `Installing oraclejdk8` fails due to "Expected feature release number in range of 9 to 14, but got: 8"
+dist: trusty
+
 cache:
   directories:
     - $HOME/.m2/repository/

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/CloserService.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/CloserService.java
@@ -1,0 +1,86 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import java.io.Closeable;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+class CloserService
+{
+    private final Set<CloseableReference> references = new ConcurrentSkipListSet<CloseableReference>();
+    private final ReferenceQueue<Object> referenceQueue = new ReferenceQueue<Object>();
+
+    void addFinalizer(Object referent, Closeable closeable)
+    {
+        references.add(new CloseableReference(referent, referenceQueue, closeable));
+    }
+
+    CloserService start()
+    {
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run()
+            {
+                processReferenceQueue();
+            }
+        });
+        thread.setName("CloserService");
+        thread.setDaemon(true);
+        thread.start();
+
+        return this;
+    }
+
+    private void processReferenceQueue()
+    {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                CloseableReference reference = (CloseableReference) referenceQueue.remove();
+                references.remove(reference);
+                reference.closeble.close();
+            }
+            catch (InterruptedException e) {
+                return;
+            }
+            catch (Throwable e) {
+                // Not use a logger to avoid adding dependencies
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static class CloseableReference
+            extends PhantomReference<Object>
+            implements Comparable
+    {
+        private final Closeable closeble;
+
+        CloseableReference(Object referent, ReferenceQueue<Object> queue, Closeable closeable)
+        {
+            super(referent, queue);
+            this.closeble = closeable;
+        }
+
+        @Override
+        public int compareTo(Object o)
+        {
+            return hashCode() - o.hashCode();
+        }
+    }
+}

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.json.JsonWriteContext;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
+import org.msgpack.core.annotations.VisibleForTesting;
 import org.msgpack.core.buffer.OutputStreamBufferOutput;
 
 import java.io.ByteArrayOutputStream;
@@ -51,7 +52,8 @@ public class MessagePackGenerator
     private LinkedList<StackItem> stack;
     private StackItem rootStackItem;
 
-    private static class BufferOutputHolder
+    @VisibleForTesting
+    static class BufferOutputHolder
             implements Closeable
     {
         private final OutputStreamBufferOutput bufferOutput;
@@ -68,6 +70,12 @@ public class MessagePackGenerator
                 throws IOException
         {
             inUse = false;
+        }
+
+        @VisibleForTesting
+        boolean isInUse()
+        {
+            return inUse;
         }
     }
 
@@ -674,5 +682,11 @@ public class MessagePackGenerator
     private MessagePacker getMessagePacker()
     {
         return messagePacker;
+    }
+
+    @VisibleForTesting
+    BufferOutputHolder getBufferOutputHolder()
+    {
+        return bufferOutputHolder;
     }
 }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/CloserServiceTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/CloserServiceTest.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class CloserServiceTest
 {

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/CloserServiceTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/CloserServiceTest.java
@@ -1,0 +1,75 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+public class CloserServiceTest
+{
+    static class Container
+    {
+        private final CloseableObject closeableObject;
+
+        static class CloseableObject
+            implements Closeable
+        {
+            private final AtomicBoolean closed;
+
+            CloseableObject(AtomicBoolean closed)
+            {
+                this.closed = closed;
+            }
+
+            @Override
+            public void close()
+                    throws IOException
+            {
+                closed.set(true);
+            }
+        }
+
+        Container(CloserService closerService, AtomicBoolean closed)
+        {
+            closeableObject = new CloseableObject(closed);
+            closerService.addFinalizer(this, closeableObject);
+        }
+    }
+
+    @Test
+    public void test()
+            throws InterruptedException
+    {
+        AtomicBoolean closed = new AtomicBoolean(false);
+        CloserService closerService = new CloserService().start();
+
+        Container container = new Container(closerService, closed);
+
+        container = null;
+
+        System.gc();
+
+        TimeUnit.MILLISECONDS.sleep(500);
+
+        assertTrue(closed.get());
+    }
+}

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -884,4 +884,29 @@ public class MessagePackGeneratorTest
             MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(bi)).unpackDouble(),
                 is(bi.doubleValue()));
     }
+
+    @Test
+    public void testNestedSerialization() throws Exception
+    {
+        ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
+        objectMapper.writeValueAsBytes(new OuterClass());
+    }
+
+    public class OuterClass
+    {
+        public String getInner() throws JsonProcessingException
+        {
+            ObjectMapper m = new ObjectMapper(new MessagePackFactory());
+            m.writeValueAsBytes(new InnerClass());
+            return "EFG";
+        }
+    }
+
+    public class InnerClass
+    {
+        public String getName()
+        {
+            return "ABC";
+        }
+    }
 }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -934,4 +934,42 @@ public class MessagePackGeneratorTest
             return name;
         }
     }
+
+    @Test
+    public void testReuseBuffer()
+            throws IOException, InterruptedException
+    {
+        JsonEncoding enc = JsonEncoding.UTF8;
+        MessagePackGenerator.BufferOutputHolder origBufferOutputHolder;
+        {
+            MessagePackGenerator generator = (MessagePackGenerator) factory.createGenerator(out, enc);
+            MessagePackGenerator.BufferOutputHolder bufferOutputHolder = generator.getBufferOutputHolder();
+            assertTrue(bufferOutputHolder.isInUse());
+            origBufferOutputHolder = bufferOutputHolder;
+            // This redundant explicit null set is required to make the object is GCed. Scoping out isn't enough...
+            generator = null;
+        }
+
+        System.gc();
+        TimeUnit.MICROSECONDS.sleep(500);
+
+        {
+            MessagePackGenerator generator = (MessagePackGenerator) factory.createGenerator(out, enc);
+            MessagePackGenerator.BufferOutputHolder bufferOutputHolder = generator.getBufferOutputHolder();
+            assertEquals(origBufferOutputHolder, bufferOutputHolder);
+            // This redundant explicit null set is required to make the object is GCed. Scoping out isn't enough...
+            generator = null;
+        }
+
+        System.gc();
+        TimeUnit.MICROSECONDS.sleep(500);
+
+        {
+            MessagePackGenerator generator = (MessagePackGenerator) factory.createGenerator(out, enc);
+            MessagePackGenerator.BufferOutputHolder bufferOutputHolder = generator.getBufferOutputHolder();
+            assertEquals(origBufferOutputHolder, bufferOutputHolder);
+            // This redundant explicit null set is required to make the object is GCed. Scoping out isn't enough...
+            generator = null;
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/msgpack/msgpack-java/issues/508

This change makes MessagePackGenerator manage status of OutputStreamBufferOutput in ThreadLocal storage to avoid manipulating a shared OutputStreamBufferOutput by multiple MessagePackGenerator(s) in the same thread. With this change, lately generated MessagePackGenerator can detect the OutputStreamBufferOutput in ThreadLocal is already `in use` and  create a new non-shared OutputStreamBufferOutput.

But it can lead an issue that if a MessagePackGenerator leaves a OutputStreamBufferOutput open in ThreadLocal, succeeding MessagePackGenerator(s) can't use the OutputStreamBufferOutput in ThreadLocal since it's still `in use` and it would affect the performance and also it's kinda leak.

So in this change, I additionally introduced CleanerService that's a sort of garbage collection. It changes the status of OutputStreamBufferOutput to `not in use` when the MessagePackGenerator gets not used.