### PR TITLE
Better class names instead of hardcoded strings

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -59,9 +59,9 @@ public class MessageBuffer
      */
     static final int ARRAY_BYTE_BASE_OFFSET;
 
-    private static final String UNIVERSAL_MESSAGE_BUFFER = "org.msgpack.core.buffer.MessageBufferU";
-    private static final String BIGENDIAN_MESSAGE_BUFFER = "org.msgpack.core.buffer.MessageBufferBE";
-    private static final String DEFAULT_MESSAGE_BUFFER = "org.msgpack.core.buffer.MessageBuffer";
+    private static final String UNIVERSAL_MESSAGE_BUFFER = org.msgpack.core.buffer.MessageBufferU.class.getName();
+    private static final String BIGENDIAN_MESSAGE_BUFFER = org.msgpack.core.buffer.MessageBufferBE.class.getName();
+    private static final String DEFAULT_MESSAGE_BUFFER = org.msgpack.core.buffer.MessageBuffer.class.getName();
 
     static {
         boolean useUniversalBuffer = false;


### PR DESCRIPTION
Using xyz.class.getName() is better than using "xyz" due to proguard and other obfuscators