### PR TITLE
Improves MessageBuffer support for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,4 @@ matrix:
   - env: PROJECT=java11
     jdk: openjdk11
     script:
-    - ./sbt test
     - ./sbt test -J-Dmsgpack.universal-buffer=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ matrix:
   - env: PROJECT=java11
     jdk: openjdk11
     script:
+    - ./sbt test
     - ./sbt test -J-Dmsgpack.universal-buffer=true

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
@@ -100,11 +100,11 @@ class DirectBufferAccess
             mGetAddress = directByteBufferClass.getDeclaredMethod("address");
             mGetAddress.setAccessible(true);
 
-            if (MessageBuffer.javaVersion >= 9) {
-                setupCleanerJava9(direct);
+            if (MessageBuffer.javaVersion <= 8) {
+                setupCleanerJava6(direct);
             }
             else {
-                setupCleanerJava6(direct);
+                setupCleanerJava9(direct);
             }
         }
         catch (Exception e) {
@@ -127,7 +127,6 @@ class DirectBufferAccess
             throw new RuntimeException((Throwable) obj);
         }
         mCleaner = (Method) obj;
-        mCleaner.setAccessible(true);
 
         obj = AccessController.doPrivileged(new PrivilegedAction<Object>()
         {
@@ -141,7 +140,6 @@ class DirectBufferAccess
             throw new RuntimeException((Throwable) obj);
         }
         mClean = (Method) obj;
-        mClean.setAccessible(true);
     }
 
     private static void setupCleanerJava9(final ByteBuffer direct)
@@ -169,6 +167,7 @@ class DirectBufferAccess
     {
         try {
             Method m = direct.getClass().getDeclaredMethod("cleaner");
+            m.setAccessible(true);
             m.invoke(direct);
             return m;
         }
@@ -194,6 +193,7 @@ class DirectBufferAccess
         try {
             Method m = mCleaner.getReturnType().getDeclaredMethod("clean");
             Object c = mCleaner.invoke(direct);
+            m.setAccessible(true);
             m.invoke(c);
             return m;
         }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
@@ -22,8 +22,6 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import org.msgpack.core.MessagePack;
-
 import sun.misc.Unsafe;
 
 /**
@@ -104,7 +102,8 @@ class DirectBufferAccess
 
             if (MessageBuffer.javaVersion >= 8) {
                 setupCleanerJava9(direct);
-            } else {
+            }
+            else {
                 setupCleanerJava6(direct);
             }
         }
@@ -113,12 +112,15 @@ class DirectBufferAccess
         }
     }
 
-    private static void setupCleanerJava6(final ByteBuffer direct) {
+    private static void setupCleanerJava6(final ByteBuffer direct)
+    {
         Object obj;
-        obj = AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        obj = AccessController.doPrivileged(new PrivilegedAction<Object>()
+        {
 
             @Override
-            public Object run() {
+            public Object run()
+            {
                 return getCleanerMethod(direct);
             }
         });
@@ -128,10 +130,11 @@ class DirectBufferAccess
         mCleaner = (Method) obj;
         mCleaner.setAccessible(true);
 
-        obj = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-
+        obj = AccessController.doPrivileged(new PrivilegedAction<Object>()
+        {
             @Override
-            public Object run() {
+            public Object run()
+            {
                 return getCleanMethod(direct, mCleaner);
             }
         });
@@ -142,11 +145,13 @@ class DirectBufferAccess
         mClean.setAccessible(true);
     }
 
-    private static void setupCleanerJava9(final ByteBuffer direct) {
-        Object obj = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-
+    private static void setupCleanerJava9(final ByteBuffer direct)
+    {
+        Object obj = AccessController.doPrivileged(new PrivilegedAction<Object>()
+        {
             @Override
-            public Object run() {
+            public Object run()
+            {
                 return getInvokeCleanerMethod(direct);
             }
         });
@@ -217,11 +222,14 @@ class DirectBufferAccess
                 "invokeCleaner", ByteBuffer.class);
             m.invoke(MessageBuffer.unsafe, direct);
             return m;
-        } catch (NoSuchMethodException e) {
+        }
+        catch (NoSuchMethodException e) {
             return e;
-        } catch (InvocationTargetException e) {
+        }
+        catch (InvocationTargetException e) {
             return e;
-        } catch (IllegalAccessException e) {
+        }
+        catch (IllegalAccessException e) {
             return e;
         }
     }
@@ -245,7 +253,8 @@ class DirectBufferAccess
             if (MessageBuffer.javaVersion <= 8) {
                 Object cleaner = mCleaner.invoke(base);
                 mClean.invoke(cleaner);
-            } else {
+            }
+	    else {
                 mInvokeCleaner.invoke(MessageBuffer.unsafe, base);
             }
         }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
@@ -100,7 +100,7 @@ class DirectBufferAccess
             mGetAddress = directByteBufferClass.getDeclaredMethod("address");
             mGetAddress.setAccessible(true);
 
-            if (MessageBuffer.javaVersion >= 8) {
+            if (MessageBuffer.javaVersion >= 9) {
                 setupCleanerJava9(direct);
             }
             else {

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/DirectBufferAccess.java
@@ -117,7 +117,6 @@ class DirectBufferAccess
         Object obj;
         obj = AccessController.doPrivileged(new PrivilegedAction<Object>()
         {
-
             @Override
             public Object run()
             {
@@ -254,7 +253,7 @@ class DirectBufferAccess
                 Object cleaner = mCleaner.invoke(base);
                 mClean.invoke(cleaner);
             }
-	    else {
+        else {
                 mInvokeCleaner.invoke(MessageBuffer.unsafe, base);
             }
         }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -165,7 +165,8 @@ public class MessageBuffer
         }
     }
 
-    static int getJavaVersion() {
+    static int getJavaVersion()
+    {
         String javaVersion = System.getProperty("java.specification.version", "");
         int dotPos = javaVersion.indexOf('.');
         if (dotPos != -1) {

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -47,6 +47,7 @@ public class MessageBuffer
 {
     static final boolean isUniversalBuffer;
     static final Unsafe unsafe;
+    static final int javaVersion = getJavaVersion();
 
     /**
      * Reference to MessageBuffer Constructors
@@ -69,9 +70,6 @@ public class MessageBuffer
         int arrayByteBaseOffset = 16;
 
         try {
-            // Check java version
-            int javaVersion = getJavaVersion();
-
             boolean hasUnsafe = false;
             try {
                 hasUnsafe = Class.forName("sun.misc.Unsafe") != null;
@@ -163,7 +161,7 @@ public class MessageBuffer
         }
     }
 
-    static int getJavaVersion()
+    private static int getJavaVersion()
     {
         String javaVersion = System.getProperty("java.specification.version", "");
         int dotPos = javaVersion.indexOf('.');

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBuffer.java
@@ -86,13 +86,11 @@ public class MessageBuffer
             boolean isGAE = System.getProperty("com.google.appengine.runtime.version") != null;
 
             // For Java6, android and JVM that has no Unsafe class, use Universal MessageBuffer (based on ByteBuffer).
-            // Java9 onward doesn't allow to access Cleaner by reflection, so we use Universal MessageBuffer again.
             useUniversalBuffer =
                     Boolean.parseBoolean(System.getProperty("msgpack.universal-buffer", "false"))
                             || isAndroid
                             || isGAE
                             || javaVersion < 7
-                            || javaVersion > 9
                             || !hasUnsafe;
 
             if (!useUniversalBuffer) {

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
@@ -258,4 +258,14 @@ public class MessageBufferU
         getBytes(0, b, 0, b.length);
         return b;
     }
+
+    @Override
+    public boolean hasArray() {
+        return !wrap.isDirect();
+    }
+
+    @Override
+    public byte[] array() {
+        return hasArray() ? wrap.array() : null;
+    }
 }

--- a/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/buffer/MessageBufferU.java
@@ -260,12 +260,14 @@ public class MessageBufferU
     }
 
     @Override
-    public boolean hasArray() {
+    public boolean hasArray()
+    {
         return !wrap.isDirect();
     }
 
     @Override
-    public byte[] array() {
+    public byte[] array()
+    {
         return hasArray() ? wrap.array() : null;
     }
 }


### PR DESCRIPTION
Switches the MessageBuffer implementation to MessageBufferU for Java versions at least 9,  which solves a couple of problems:

1. On Java 11 (OpenJDK) jdk.internal.ref.Cleaner#clean is not open to reflection and the static initializer of DirectBufferAccess throws an IllegalAccessException.
2. Access to java.nio.DirectByteBuffer may suffer the same problem in the future. For now we just get a warning.

Since MessageBufferU overrides almost all methods of MessageBuffer, while direct ByteBuffers register a cleaner by themself, I don't see why MessageBufferU(ByteBuffer) shouldn't accept direct buffers.

This should also solve bug number #482.