### PR TITLE
Update build settings to use latest version of sbt and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ lib
 .idea
 atlassian-ide-plugin.xml
 .idea/copyright/msgpack.xml
+.bsp

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Here is a list of sbt commands for daily development:
 
 > release                 # Run the release procedure (set a new version, run tests, upload artifacts, then deploy to Sonatype)
 
-# If you need to perform the individual release steps manually, use the following commands:
+# [optional] When you need to perform the individual release steps manually, use the following commands:
 > publishSigned           # Publish GPG signed artifacts to the Sonatype repository
-> sonatypeRelease         # Publish to the Maven Central (It will be synched within less than 4 hours)
+> sonatypeBundleRelease   # Publish to the Maven Central (It will be synched within less than 4 hours)
 ```
 
 For publishing to Maven central, msgpack-java uses [sbt-sonatype](https://github.com/xerial/sbt-sonatype) plugin. Set Sonatype account information (user name and password) in the global sbt settings. To protect your password, never include this file in your project.

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.8
+sbt.version=1.5.2
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,12 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release"     % "1.0.11")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % "2.5")
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"         % "1.1.2")
-addSbtPlugin("com.github.sbt"    % "sbt-findbugs"    % "2.0.0")
-addSbtPlugin("com.github.sbt"    % "sbt-jacoco"      % "3.0.3")
-addSbtPlugin("org.xerial.sbt"    % "sbt-jcheckstyle" % "0.2.1")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-osgi"        % "0.9.5")
-addSbtPlugin("io.get-coursier"   % "sbt-coursier"    % "1.0.3")
-addSbtPlugin("com.geirsson"      % "sbt-scalafmt"    % "1.5.1")
+addSbtPlugin("com.github.sbt"   % "sbt-release"     % "1.0.15")
+addSbtPlugin("org.xerial.sbt"   % "sbt-sonatype"    % "3.9.7")
+addSbtPlugin("com.github.sbt"   % "sbt-pgp"         % "2.1.2")
+addSbtPlugin("com.github.sbt"   % "sbt-findbugs"    % "2.0.0")
+// TODO: Fixes jacoco error:
+// java.lang.NoClassDefFoundError: Could not initialize class org.jacoco.core.internal.flow.ClassProbesAdapter
+//addSbtPlugin("com.github.sbt"   % "sbt-jacoco"      % "3.3.0")
+addSbtPlugin("org.xerial.sbt"   % "sbt-jcheckstyle" % "0.2.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi"        % "0.9.5")
+addSbtPlugin("org.scalameta"    % "sbt-scalafmt"    % "2.4.2")
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/sbt
+++ b/sbt
@@ -34,11 +34,11 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.3.13"
-declare -r sbt_unreleased_version="1.4.0-M1"
+declare -r sbt_release_version="1.5.1"
+declare -r sbt_unreleased_version="1.5.1"
 
-declare -r latest_213="2.13.3"
-declare -r latest_212="2.12.12"
+declare -r latest_213="2.13.5"
+declare -r latest_212="2.12.13"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"
@@ -48,7 +48,7 @@ declare -r buildProps="project/build.properties"
 
 declare -r sbt_launch_ivy_release_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
-declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_release_repo="https://repo1.maven.org/maven2"
 declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
 declare -r default_jvm_opts_common="-Xms512m -Xss2m -XX:MaxInlineLevel=18"
@@ -247,11 +247,18 @@ java_version() {
   echo "$version"
 }
 
+is_apple_silicon() { [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; }
+
 # MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
 default_jvm_opts() {
   local -r v="$(java_version)"
   if [[ $v -ge 10 ]]; then
-    echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+    if is_apple_silicon; then
+      # As of Dec 2020, JVM for Apple Silicon (M1) doesn't support JVMCI
+      echo "$default_jvm_opts_common"
+    else
+      echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+    fi
   elif [[ $v -ge 8 ]]; then
     echo "$default_jvm_opts_common"
   else
@@ -471,7 +478,7 @@ process_args() {
       -trace)       require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
       -debug-inc)   addJava "-Dxsbt.inc.debug=true" && shift ;;
 
-      -no-colors)   addJava "-Dsbt.log.noformat=true" && shift ;;
+      -no-colors)   addJava "-Dsbt.log.noformat=true" && addJava "-Dsbt.color=false" && shift ;;
       -sbt-create)  sbt_create=true && shift ;;
       -sbt-dir)     require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
       -sbt-boot)    require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.23-SNAPSHOT"
+ThisBuild / version := "0.8.23-SNAPSHOT"


### PR DESCRIPTION
- Updated sbt and its plugins
- Fixed build.sbt to use slash syntaxes https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
- Upgraded sbt-sonatype to the latest version to have more release stability.
- Code coverage test doesn't work well with Jacoco. We need another coverage solution