### PR TITLE
Add a script for releasing a new version of msgpack-java at CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release to Sonatype
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 10000
+      # Fetch all tags so that sbt-dynver can find the previous release version
+      - run: git fetch --tags -f
+      # Install OpenJDK 11
+      - uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+      - name: Setup GPG
+        env:
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        run: echo $PGP_SECRET | base64 --decode | gpg --import --batch --yes
+      - name: Build bundle
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: |
+          ./sbt publish
+      - name: Release to Sonatype
+        env:
+          SONATYPE_USERNAME: '${{ secrets.SONATYPE_USER }}'
+          SONATYPE_PASSWORD: '${{ secrets.SONATYPE_PASS }}'
+        run: ./sbt sonatypeBundleRelease

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ Here is a list of sbt commands for daily development:
 > sonatypeBundleRelease   # Publish to the Maven Central (It will be synched within less than 4 hours)
 ```
 
-For publishing to Maven central, msgpack-java uses [sbt-sonatype](https://github.com/xerial/sbt-sonatype) plugin. Set Sonatype account information (user name and password) in the global sbt settings. To protect your password, never include this file in your project.
+Once you run a release command, a new git tag v(version number) will be pushed to GitHub. GitHub Action will deploy a new release version to Maven Central (Sonatype).
+
+For publishing to Maven central using a local machine, msgpack-java uses [sbt-sonatype](https://github.com/xerial/sbt-sonatype) plugin. Set Sonatype account information (user name and password) in the global sbt settings. To protect your password, never include this file in your project.
 
 ___$HOME/.sbt/(sbt-version)/sonatype.sbt___
 

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ val buildSettings = Seq[Setting[_]](
   // msgpack-java should be a pure-java library, so remove Scala specific configurations
   autoScalaLibrary := false,
   crossPaths := false,
+  publishMavenStyle := true,
   // JVM options for building
   scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked", "-feature"),
   Test / javaOptions ++= Seq("-ea"),

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,46 +1,18 @@
-sonatypeProfileName := "org.msgpack"
+import xerial.sbt.Sonatype._
 
-pomExtra in Global := {
-  <url>http://msgpack.org/</url>
-    <licenses>
-      <license>
-        <name>Apache 2</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      </license>
-    </licenses>
-    <scm>
-      <connection>scm:git:github.com/msgpack/msgpack-java.git</connection>
-      <developerConnection>scm:git:git@github.com:msgpack/msgpack-java.git</developerConnection>
-      <url>github.com/msgpack/msgpack-java.git</url>
-    </scm>
-    <properties>
-      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <developers>
-      <developer>
-        <id>frsyuki</id>
-        <name>Sadayuki Furuhashi</name>
-        <email>frsyuki@users.sourceforge.jp</email>
-      </developer>
-      <developer>
-        <id>muga</id>
-        <name>Muga Nishizawa</name>
-        <email>muga.nishizawa@gmail.com</email>
-      </developer>
-      <developer>
-        <id>oza</id>
-        <name>Tsuyoshi Ozawa</name>
-        <url>https://github.com/oza</url>
-      </developer>
-      <developer>
-        <id>komamitsu</id>
-        <name>Mitsunori Komatsu</name>
-        <email>komamitsu@gmail.com</email>
-      </developer>
-      <developer>
-        <id>xerial</id>
-        <name>Taro L. Saito</name>
-        <email>leo@xerial.org</email>
-      </developer>
-    </developers>
-}
+ThisBuild / sonatypeProfileName := "org.msgpack"
+ThisBuild / homepage := Some(url("https://msgpack.org/"))
+ThisBuild / licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/msgpack/msgpack-java"),
+    "scm:git@github.com:msgpack/msgpack-java.git"
+  )
+)
+ThisBuild / developers := List(
+  Developer(id = "frsyuki", name = "Sadayuki Furuhashi", email = "frsyuki@users.sourceforge.jp", url = url("https://github.com/frsyuki")),
+  Developer(id = "muga", name = "Muga Nishizawa", email = "muga.nishizawa@gmail.com", url = url("https://github.com/muga")),
+  Developer(id = "oza", name = "Tsuyoshi Ozawa", email = "ozawa.tsuyoshi@gmail.com", url = url("https://github.com/oza")),
+  Developer(id = "komamitsu", name = "Mitsunori Komatsu", email = "komamitsu@gmail.com", url = url("https://github.com/komamitsu")),
+  Developer(id = "xerial", name = "Taro L. Saito", email = "leo@xerial.org", url = url("https://github.com/xerial"))
+)


### PR DESCRIPTION
With this change, we just need to push a new tag version to publish a new release to Sonatype. 

A new release procedure:
- Run `./sbt releaese` and choose a new version prefixed with `v` (e.g., v0.8.23)
- GitHub action will publish the new release version to Sonatype (Maven Central)

cc: @komamitsu 