### PR TITLE
Specify the bufferSize of the ArrayBufferOutput

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageBufferPacker.java
@@ -34,7 +34,7 @@ public class MessageBufferPacker
 {
     protected MessageBufferPacker(MessagePack.PackerConfig config)
     {
-        this(new ArrayBufferOutput(), config);
+        this(new ArrayBufferOutput(config.getBufferSize()), config);
     }
 
     protected MessageBufferPacker(ArrayBufferOutput out, MessagePack.PackerConfig config)


### PR DESCRIPTION
Use the bufferSize of PackerConfig to specify the bufferSize of the ArrayBufferOutput in MessageBufferPacker.