### PR TITLE
Keep consistent read size after closing MessageUnpacker

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java
@@ -1735,6 +1735,7 @@ public class MessageUnpacker
     public void close()
             throws IOException
     {
+        totalReadBytes += position;
         buffer = EMPTY_BUFFER;
         position = 0;
         in.close();

--- a/msgpack-core/src/test/scala/org/msgpack/core/MessageUnpackerTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessageUnpackerTest.scala
@@ -254,6 +254,9 @@ class MessageUnpackerTest extends AirSpec with Benchmark {
         }
         count shouldBe 6
         unpacker.getTotalReadBytes shouldBe arr.length
+
+        unpacker.close()
+        unpacker.getTotalReadBytes shouldBe arr.length
       }
     }
 
@@ -267,6 +270,9 @@ class MessageUnpackerTest extends AirSpec with Benchmark {
         }
 
         skipCount shouldBe 2
+        unpacker.getTotalReadBytes shouldBe testData.length
+
+        unpacker.close()
         unpacker.getTotalReadBytes shouldBe testData.length
       }
     }
@@ -322,6 +328,9 @@ class MessageUnpackerTest extends AirSpec with Benchmark {
 
         ib.result() shouldBe intSeq.toSeq
         unpacker.getTotalReadBytes shouldBe testData2.length
+
+        unpacker.close()
+        unpacker.getTotalReadBytes shouldBe testData2.length
       }
     }
 
@@ -351,6 +360,9 @@ class MessageUnpackerTest extends AirSpec with Benchmark {
                 readValue(unpacker)
               }
               count shouldBe numElems
+              unpacker.getTotalReadBytes shouldBe data.length
+
+              unpacker.close()
               unpacker.getTotalReadBytes shouldBe data.length
             }
           }
@@ -868,6 +880,9 @@ class MessageUnpackerTest extends AirSpec with Benchmark {
           unpacker.unpackString.length shouldBe n
           unpacker.unpackInt shouldBe 1
 
+          unpacker.getTotalReadBytes shouldBe arr.length
+
+          unpacker.close()
           unpacker.getTotalReadBytes shouldBe arr.length
         }
       }


### PR DESCRIPTION
I found `MessageUnpacker#getTotalReadBytes` doesn't return correct size once I invoke `MessageUnpacker#close`.

That's because `MessageUnpacker#close` drops the current buffer without updating the read size
https://github.com/msgpack/msgpack-java/blob/v0.9.0/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java#L1738-L1740

even though `MessageUnpacker#getTotalReadBytes` requires the size of the latest buffer.
https://github.com/msgpack/msgpack-java/blob/v0.9.0/msgpack-core/src/main/java/org/msgpack/core/MessageUnpacker.java#L261