### PR TITLE
Fixed examples relative link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ dependencies {
 ### Integration with Jackson ObjectMapper (jackson-databind)
 
 msgpack-java supports serialization and deserialization of Java objects through [jackson-databind](https://github.com/FasterXML/jackson-databind).
-For details, see [msgpack-jackson/README.md](msgpack-jackson/README.md). The template-based serialization mechanism used in v06 is deprecated.
+For details, see [msgpack-jackson/README.md](https://github.com/msgpack/msgpack-java/blob/develop/msgpack-jackson/README.md). The template-based serialization mechanism used in v06 is deprecated.
 
-- [Release Notes](RELEASE_NOTES.md)
+- [Release Notes](https://github.com/msgpack/msgpack-java/blob/develop/RELEASE_NOTES.md)
 
 ## For MessagePack Developers [![Travis CI](https://travis-ci.org/msgpack/msgpack-java.svg?branch=v07-develop)](https://travis-ci.org/msgpack/msgpack-java)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dependencies {
 }
 ```
 
-- [Usage examples](msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java)
+- [Usage examples](https://github.com/msgpack/msgpack-java/blob/develop/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java)
 
 ### Integration with Jackson ObjectMapper (jackson-databind)
 


### PR DESCRIPTION
On the [message pack](https://msgpack.org/index.html) mirror of the readme, since this is relatively linked, it attempts to route to the location https://msgpack.org/msgpack/msgpack-java/blob/develop/msgpack-core/src/test/java/org/msgpack/core/example/MessagePackExample.java which subsequently returns a 404. Statically linking the domain should fix this issue and look a lot more professional. I personally almost didn't use this implementation since I did not realize this was an unintentional side effect.


And yes, I'm making a PR to change one line in the README.