### PR TITLE
Use SPDX-ID in license name

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 This product includes the software developed by third-party:
 
- * Google Guava https://code.google.com/p/guava-libraries/  (APL2)
+ * Google Guava https://code.google.com/p/guava-libraries/  (Apache-2.0)
  * sbt-extras: https://github.com/paulp/sbt-extras  (BSD)  (LICENSE.sbt-extras.txt)
 

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -2,7 +2,7 @@ import xerial.sbt.Sonatype._
 
 ThisBuild / sonatypeProfileName := "org.msgpack"
 ThisBuild / homepage := Some(url("https://msgpack.org/"))
-ThisBuild / licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/msgpack/msgpack-java"),


### PR DESCRIPTION
Change the license name to the SPDX-ID equivalent.
See: https://spdx.org/licenses/

This will Resolve #652 