### PR TITLE
adding a method writePayload(String src) 

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
+++ b/msgpack-core/src/main/java/org/msgpack/core/MessagePacker.java
@@ -1182,4 +1182,25 @@ public class MessagePacker
         }
         return this;
     }
+
+    /**
+     * This method copies the lower 8-bits of the characters.
+     * A separate writePayload(String src) method would be more performant because we're able to
+     * directly copy the bytes from the string to the right location in MessageBuffer.  Introducing
+     * encoding in an attempt to re-use the existing writePayload(byte[] src) creates unnecessary overhead
+     * which in turn will affect performance.
+     *
+     * @param src the string data to add
+     * @return this
+     * @throws IOException
+     */
+
+    public MessagePacker writePayload(String src) throws IOException
+    {
+        int len = src.length();
+        ensureCapacity(len);
+        src.getBytes(0, len, buffer.array(), position);
+        position += len;
+        return this;
+    }
 }


### PR DESCRIPTION
This new method copies the lower 8-bits of the characters.  A separate writePayload(String src) method would be more performant because we're able to directly copy the bytes from the string to the right location in MessageBuffer.  Introducing encoding in an attempt to re-use the existing writePayload(byte[] src) creates unnecessary overhead which in turn will affect performance.