### PR TITLE
Small improvement of msgpack-jackson bench

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ on:
       - '**.java'
       - '**.sbt'
       - '.github/workflows/**.yml'
+    workflow_dispatch:
 
 jobs:
   code_format:

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/benchmark/MessagePackDataformatHugeDataBenchmarkTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/benchmark/MessagePackDataformatHugeDataBenchmarkTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class MessagePackDataformatHugeDataBenchmarkTest
 {
-    private static final int ELM_NUM = 100000;
+    private static final int ELM_NUM = 1000000;
     private static final int COUNT = 6;
     private static final int WARMUP_COUNT = 4;
     private final ObjectMapper origObjectMapper = new ObjectMapper();


### PR DESCRIPTION
This PR does:
- Add `workflow_dispatch` event to the GitHub Action workflows so that we can manually kick the CI with a specific branch
- Increase the test data size used in `org.msgpack.jackson.dataformat.benchmark.MessagePackDataformatHugeDataBenchmarkTest`

