### PR TITLE
Introduce release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🔥 Breaking Changes'
+    labels:
+      - 'breaking'
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '👋 Deprecated'
+    labels:
+      - 'deprecation'
+  - title: '🔗 Dependency Updates'
+    labels:
+      - 'library-update'
+      - 'dependencies'
+  - title: '🛠  Internal Updates'
+    labels:
+      - 'internal'
+      - 'kaizen'
+      - 'test-library-update'
+      - 'sbt-plugin-update'
+  - title: '📚 Docs'
+    labels:
+      - 'doc'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+
+autolabeler:
+  - label: 'doc'
+    files:
+      - '*.md'
+  - label: 'feature'
+    title:
+      - '/(support|add)/i'
+  - label: 'bug'
+    title:
+      - '/fix/i'
+  - label: 'internal'
+    title:
+      - '/internal/i'
+  - label: 'deprecation'
+    title:
+      - '/deprecate/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,31 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,8 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - develop
+      - main
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ git tag v0.x.y
 $ git push origin v0.x.y
 ```
 
-A draft of the next release note will be updated automatically at the [GitHub Releases](https://github.com/msgpack/msgpack-java/releases) page. For eachPR merged, [release-drafter](https://github.com/release-drafter/release-drafter) will modify the release note draftd. When you create a new release tag, edit and publish the draft of the release note. If necessary, adjust the version number and target tag.
+A draft of the next release note will be updated automatically at the [GitHub Releases](https://github.com/msgpack/msgpack-java/releases) page. For each PR merged, [release-drafter](https://github.com/release-drafter/release-drafter) will modify the release note draft. When you create a new release tag, edit and publish the draft of the release note. If necessary, adjust the version number and target tag.
 
 #### Publishing to Sonatype from Local Machine
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,8 @@ Here is a list of sbt commands for daily development:
 > ~testOnly *MessagePackTest -- (pattern)  # Run tests matching the pattern 
 > project msgpack-core                     # Focus on a specific project
 > package                                  # Create a jar file in the target folder of each project
-> findbugs                                 # Produce findbugs report in target/findbugs
-> jacoco:cover                             # Report the code coverage of tests to target/jacoco folder
 > jcheckStyle                              # Run check style
-> ;scalafmt;test:scalafmt;scalafmtSbt      # Reformat Scala codes
+> scalafmtAll                              # Reformat code
 ```
 
 ### Publishing
@@ -105,10 +103,7 @@ $ git tag v0.x.y
 $ git push origin v0.x.y
 ```
 
-To generate a release notes, you can use this command line:
-```
-$ git log v(last version).. --oneline | cut -f 2- -d ' ' | perl -npe 's/(.*)\(\#([0-9]+)\)/* \1\[\#\2\]\(http:\/\/github.com\/msgpack\/msgpack-java\/pull\/\2\)/g'
-```
+Release notes will be automatically updated a draft of the next release not at the [GitHub Releases](https://github.com/msgpack/msgpack-java/releases) page using [release-drafter](https://github.com/release-drafter/release-drafter). For each PR merged, the release note will be updated. When you create a new release tag, edit and publish the draft of the release note. If necessary, adjust the version number and target tag.
 
 #### Publishing to Sonatype from Local Machine
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ $ git tag v0.x.y
 $ git push origin v0.x.y
 ```
 
-Release notes will be automatically updated a draft of the next release not at the [GitHub Releases](https://github.com/msgpack/msgpack-java/releases) page using [release-drafter](https://github.com/release-drafter/release-drafter). For each PR merged, the release note will be updated. When you create a new release tag, edit and publish the draft of the release note. If necessary, adjust the version number and target tag.
+A draft of the next release note will be updated automatically at the [GitHub Releases](https://github.com/msgpack/msgpack-java/releases) page. For eachPR merged, [release-drafter](https://github.com/release-drafter/release-drafter) will modify the release note draftd. When you create a new release tag, edit and publish the draft of the release note. If necessary, adjust the version number and target tag.
 
 #### Publishing to Sonatype from Local Machine
 


### PR DESCRIPTION
Note: CI will be broken because release-drafter requires configuration files in the main branches, not in the PR branch.