### PR TITLE
feature: Support JDK21 (and drop JDK7 support) 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,24 @@ jobs:
       - uses: actions/checkout@v2
       - name: jcheckstyle
         run: ./sbt jcheckStyle
+  test_jdk21:
+    name: Test JDK21
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-jdk21-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-jdk21-
+      - name: Test
+        run: ./sbt test
+      - name: Universal Buffer Test
+        run: ./sbt test -J-Dmsgpack.universal-buffer=true
   test_jdk17:
     name: Test JDK17
     runs-on: ubuntu-latest
@@ -39,7 +57,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-jdk11-${{ hashFiles('**/*.sbt') }}
+          key: ${{ runner.os }}-jdk17-${{ hashFiles('**/*.sbt') }}
           restore-keys: ${{ runner.os }}-jdk17-
       - name: Test
         run: ./sbt test

--- a/build.sbt
+++ b/build.sbt
@@ -26,11 +26,11 @@ val buildSettings = Seq[Setting[_]](
   // JVM options for building
   scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked", "-feature"),
   Test / javaOptions ++= Seq("-ea"),
-  javacOptions ++= Seq("-source", "1.7", "-target", "1.7"),
+  javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
   Compile / compile / javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:unchecked", "-Xlint:deprecation"),
   // Use lenient validation mode when generating Javadoc (for Java8)
   doc / javacOptions := {
-    val opts = Seq("-source", "1.7")
+    val opts = Seq("-source", "1.8")
     if (scala.util.Properties.isJavaAtLeast("1.8")) {
       opts ++ Seq("-Xdoclint:none")
     } else {
@@ -92,7 +92,7 @@ lazy val msgpackCore = Project(id = "msgpack-core", base = file("msgpack-core"))
       "org.msgpack" % "msgpack" % "0.6.12" % "test",
       // For integration test with Akka
       "com.typesafe.akka"      %% "akka-actor"              % "2.6.20" % "test",
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0"  % "test"
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0" % "test"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val buildSettings = Seq[Setting[_]](
   organizationName := "MessagePack",
   organizationHomepage := Some(new URL("http://msgpack.org/")),
   description := "MessagePack for Java",
-  scalaVersion := "2.13.6",
+  scalaVersion := "2.13.12",
   Test / logBuffered := false,
   // msgpack-java should be a pure-java library, so remove Scala specific configurations
   autoScalaLibrary := false,


### PR DESCRIPTION
This also drops JDK7 support. 

An error: 
```
Caused by: java.lang.ClassNotFoundException: java.nio.MemoryBlock
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:421)
	at java.base/java.lang.Class.forName(Class.java:412)
	at org.msgpack.core.buffer.DirectBufferAccess.<clinit>(DirectBufferAccess.java:84)
```

Related: Remove private DirectByteBuffer(long, int) constructor before JDK 21 GA https://bugs.openjdk.org/browse/JDK-8303083. In JDK21, DirectByteBuffer(long, long) constructor can be used.