### PR TITLE
Fix fixint test in MessagePackTest.

### DIFF
--- a/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
+++ b/msgpack-core/src/test/scala/org/msgpack/core/MessagePackTest.scala
@@ -78,7 +78,7 @@ class MessagePackTest extends AirSpec with PropertyCheck with Benchmark {
 
   test("detect fixint values") {
 
-    for (i <- 0 until 0x79) {
+    for (i <- 0 until 0x7f) {
       Code.isPosFixInt(i.toByte) shouldBe true
     }
 


### PR DESCRIPTION
According to [msgpack format spec](https://github.com/msgpack/msgpack/blob/master/spec.md#formats), positive fix int ranges from 0x00 to 0x7f. The test only covers from 0x00 to 0x79. 