### PR TITLE
Fix bug in ImmutableTimestampValueImpl.

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableTimestampValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableTimestampValueImpl.java
@@ -93,7 +93,7 @@ public class ImmutableTimestampValueImpl
             long sec = getEpochSecond();
             int nsec = getNano();
             if (sec >>> 34 == 0) {
-                long data64 = ((long)nsec << 34) | sec;
+                long data64 = ((long) nsec << 34) | sec;
                 if ((data64 & 0xffffffff00000000L) == 0L) {
                     bytes = new byte[4];
                     MessageBuffer.wrap(bytes).putInt(0, (int) sec);

--- a/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableTimestampValueImpl.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/impl/ImmutableTimestampValueImpl.java
@@ -93,7 +93,7 @@ public class ImmutableTimestampValueImpl
             long sec = getEpochSecond();
             int nsec = getNano();
             if (sec >>> 34 == 0) {
-                long data64 = (nsec << 34) | sec;
+                long data64 = ((long)nsec << 34) | sec;
                 if ((data64 & 0xffffffff00000000L) == 0L) {
                     bytes = new byte[4];
                     MessageBuffer.wrap(bytes).putInt(0, (int) sec);


### PR DESCRIPTION
`ImmutableTimestampValueImpl.getData()` shifts `nsec` (which is a 32-bit `int`) by 34 bits. 