### PR TITLE
Fix ClassCastException when array values is set as List

### DIFF
--- a/msgpack-core/src/main/java/org/msgpack/value/Variable.java
+++ b/msgpack-core/src/main/java/org/msgpack/value/Variable.java
@@ -817,7 +817,7 @@ public class Variable
     {
         this.type = Type.LIST;
         this.accessor = arrayAccessor;
-        this.objectValue = v.toArray();
+        this.objectValue = v.toArray(new Value[v.size()]);
         return this;
     }
 


### PR DESCRIPTION
```
java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [Lorg.msgpack.value.Value; ([Ljava.lang.Object; is in module java.base of loader 'bootstrap'; [Lorg.msgpack.value.Value; is in unnamed module of loader 'app')
        at org.msgpack.value.Variable$ArrayValueAccessor.array(Variable.java:890)
        at org.msgpack.value.Variable$ArrayValueAccessor.immutableValue(Variable.java:851)
        at org.msgpack.value.Variable$ArrayValueAccessor.immutableValue(Variable.java:832)
        at org.msgpack.value.Variable.immutableValue(Variable.java:1136)
        at org.msgpack.value.Variable.toJson(Variable.java:1161)
```