### PR TITLE
Make the MessagePackParser#type field public

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
@@ -64,11 +64,11 @@ public class MessagePackParser
     private final IOContext ioContext;
     private ExtensionTypeCustomDeserializers extTypeCustomDesers;
 
-    private enum Type
+    public enum Type
     {
         INT, LONG, DOUBLE, STRING, BYTES, BIG_INT, EXT
     }
-    private Type type;
+    public Type type;
     private int intValue;
     private long longValue;
     private double doubleValue;


### PR DESCRIPTION
It's useful when you need to distinguishe bytes array from extension type

Closes #799 