### PR TITLE
Bump the version of `jackson-databind`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ lazy val msgpackJackson =
         "org.msgpack.jackson.dataformat"
       ),
       libraryDependencies ++= Seq(
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.16.2",
+        "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.2",
         junitInterface,
         "org.apache.commons" % "commons-math3" % "3.6.1" % "test"
       ),

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -2,7 +2,6 @@ package org.msgpack.jackson.dataformat;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
@@ -32,22 +31,5 @@ public class JsonArrayFormat extends JacksonAnnotationIntrospector
     }
 
     return ARRAY_FORMAT;
-  }
-
-  /**
-   * Defines that unknown properties will be ignored, and won't fail the un-marshalling process.
-   * Happens in case of de-serialization of a payload that contains more properties than the actual
-   * value type
-   */
-  @Override
-  public Boolean findIgnoreUnknownProperties(AnnotatedClass ac)
-  {
-    // If the entity contains JsonIgnoreProperties annotation, give it higher priority.
-    final Boolean precedenceIgnoreUnknownProperties = super.findIgnoreUnknownProperties(ac);
-    if (precedenceIgnoreUnknownProperties != null) {
-      return precedenceIgnoreUnknownProperties;
-    }
-
-    return true;
   }
 }


### PR DESCRIPTION
Recent PRs from Scala Steward to upgrade `com.fasterxml.jackson.core:jackson-databind` have failed https://github.com/msgpack/msgpack-java/pull/856. This is because a deprecated API referenced by `msgpack-jackson` module was removed in the latest `jackson-databind`. This PR addresses the issue.