### PR TITLE
Add support for jackson field ids

### DIFF
--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -39,7 +39,7 @@ public class MessagePackFactory
     private final MessagePack.PackerConfig packerConfig;
     private boolean reuseResourceInGenerator = true;
     private boolean reuseResourceInParser = true;
-    private boolean writeIntegerKeysAsStringKeys = true;
+    private boolean supportIntegerKeys = false;
     private ExtensionTypeCustomDeserializers extTypeCustomDesers;
 
     public MessagePackFactory()
@@ -75,9 +75,9 @@ public class MessagePackFactory
         return this;
     }
 
-    public MessagePackFactory setWriteIntegerKeysAsStringKeys(boolean writeIntegerKeysAsStringKeys)
+    public MessagePackFactory setSupportIntegerKeys(boolean supportIntegerKeys)
     {
-        this.writeIntegerKeysAsStringKeys = writeIntegerKeysAsStringKeys;
+        this.supportIntegerKeys = supportIntegerKeys;
         return this;
     }
 
@@ -91,7 +91,7 @@ public class MessagePackFactory
     public JsonGenerator createGenerator(OutputStream out, JsonEncoding enc)
             throws IOException
     {
-        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out, packerConfig, reuseResourceInGenerator, writeIntegerKeysAsStringKeys);
+        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out, packerConfig, reuseResourceInGenerator, supportIntegerKeys);
     }
 
     @Override

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -39,6 +39,7 @@ public class MessagePackFactory
     private final MessagePack.PackerConfig packerConfig;
     private boolean reuseResourceInGenerator = true;
     private boolean reuseResourceInParser = true;
+    private boolean writeIntegerKeysAsStringKeys = true;
     private ExtensionTypeCustomDeserializers extTypeCustomDesers;
 
     public MessagePackFactory()
@@ -74,6 +75,12 @@ public class MessagePackFactory
         return this;
     }
 
+    public MessagePackFactory setWriteIntegerKeysAsStringKeys(boolean writeIntegerKeysAsStringKeys)
+    {
+        this.writeIntegerKeysAsStringKeys = writeIntegerKeysAsStringKeys;
+        return this;
+    }
+
     public MessagePackFactory setExtTypeCustomDesers(ExtensionTypeCustomDeserializers extTypeCustomDesers)
     {
         this.extTypeCustomDesers = extTypeCustomDesers;
@@ -84,7 +91,7 @@ public class MessagePackFactory
     public JsonGenerator createGenerator(OutputStream out, JsonEncoding enc)
             throws IOException
     {
-        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out, packerConfig, reuseResourceInGenerator);
+        return new MessagePackGenerator(_generatorFeatures, _objectCodec, out, packerConfig, reuseResourceInGenerator, writeIntegerKeysAsStringKeys);
     }
 
     @Override

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -513,12 +513,11 @@ public class MessagePackGenerator
         addValueNode(new String(text, offset, len, DEFAULT_CHARSET));
     }
 
-    // TODO: Uncomment
-    //@Override
-    //public void writeFieldId(long id) throws IOException
-    //{
-    //    addKeyToStackTop(id);
-    //}
+    @Override
+    public void writeFieldId(long id) throws IOException
+    {
+        addKeyNode(id);
+    }
 
     @Override
     public void writeFieldName(String name)

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -513,6 +513,13 @@ public class MessagePackGenerator
         addValueNode(new String(text, offset, len, DEFAULT_CHARSET));
     }
 
+    // TODO: Uncomment
+    //@Override
+    //public void writeFieldId(long id) throws IOException
+    //{
+    //    addKeyToStackTop(id);
+    //}
+
     @Override
     public void writeFieldName(String name)
     {

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -50,6 +50,7 @@ public class MessagePackGenerator
     private static final ThreadLocal<OutputStreamBufferOutput> messageBufferOutputHolder = new ThreadLocal<>();
     private final OutputStream output;
     private final MessagePack.PackerConfig packerConfig;
+    private final boolean writeIntegerKeysAsStringKeys;
 
     private int currentParentElementIndex = -1;
     private int currentState = IN_ROOT;
@@ -195,6 +196,7 @@ public class MessagePackGenerator
         this.messagePacker = packerConfig.newPacker(out);
         this.packerConfig = packerConfig;
         this.nodes = new ArrayList<>();
+        this.writeIntegerKeysAsStringKeys = true;
     }
 
     public MessagePackGenerator(
@@ -210,6 +212,24 @@ public class MessagePackGenerator
         this.messagePacker = packerConfig.newPacker(getMessageBufferOutputForOutputStream(out, reuseResourceInGenerator));
         this.packerConfig = packerConfig;
         this.nodes = new ArrayList<>();
+        this.writeIntegerKeysAsStringKeys = true;
+    }
+
+    public MessagePackGenerator(
+            int features,
+            ObjectCodec codec,
+            OutputStream out,
+            MessagePack.PackerConfig packerConfig,
+            boolean reuseResourceInGenerator,
+            boolean writeIntegerKeysAsStringKeys)
+            throws IOException
+    {
+        super(features, codec);
+        this.output = out;
+        this.messagePacker = packerConfig.newPacker(getMessageBufferOutputForOutputStream(out, reuseResourceInGenerator));
+        this.packerConfig = packerConfig;
+        this.nodes = new ArrayList<>();
+        this.writeIntegerKeysAsStringKeys = writeIntegerKeysAsStringKeys;
     }
 
     private MessageBufferOutput getMessageBufferOutputForOutputStream(
@@ -516,7 +536,12 @@ public class MessagePackGenerator
     @Override
     public void writeFieldId(long id) throws IOException
     {
-        addKeyNode(id);
+        if (this.writeIntegerKeysAsStringKeys) {
+            super.writeFieldId(id);
+        }
+        else {
+            addKeyNode(id);
+        }
     }
 
     @Override

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -189,30 +189,15 @@ public class MessagePackGenerator
             int features,
             ObjectCodec codec,
             OutputStream out,
-            MessagePack.PackerConfig packerConfig)
+            MessagePack.PackerConfig packerConfig,
+            boolean writeIntegerKeysAsStringKeys)
     {
         super(features, codec);
         this.output = out;
         this.messagePacker = packerConfig.newPacker(out);
         this.packerConfig = packerConfig;
         this.nodes = new ArrayList<>();
-        this.writeIntegerKeysAsStringKeys = true;
-    }
-
-    public MessagePackGenerator(
-            int features,
-            ObjectCodec codec,
-            OutputStream out,
-            MessagePack.PackerConfig packerConfig,
-            boolean reuseResourceInGenerator)
-            throws IOException
-    {
-        super(features, codec);
-        this.output = out;
-        this.messagePacker = packerConfig.newPacker(getMessageBufferOutputForOutputStream(out, reuseResourceInGenerator));
-        this.packerConfig = packerConfig;
-        this.nodes = new ArrayList<>();
-        this.writeIntegerKeysAsStringKeys = true;
+        this.writeIntegerKeysAsStringKeys = writeIntegerKeysAsStringKeys;
     }
 
     public MessagePackGenerator(
@@ -393,7 +378,7 @@ public class MessagePackGenerator
         else {
             messagePacker.flush();
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            MessagePackGenerator messagePackGenerator = new MessagePackGenerator(getFeatureMask(), getCodec(), outputStream, packerConfig);
+            MessagePackGenerator messagePackGenerator = new MessagePackGenerator(getFeatureMask(), getCodec(), outputStream, packerConfig, writeIntegerKeysAsStringKeys);
             getCodec().writeValue(messagePackGenerator, v);
             output.write(outputStream.toByteArray());
         }

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
@@ -621,10 +621,10 @@ public class MessagePackParser
         return streamReadContext.getCurrentName();
     }
 
-    // TODO: Uncomment
-    //public boolean isCurrentFieldId() {
-    //    return this.type == Type.INT || this.type == Type.LONG;
-    //}
+    public boolean isCurrentFieldId()
+    {
+        return this.type == Type.INT || this.type == Type.LONG;
+    }
 
     @Override
     public String getCurrentName()

--- a/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
+++ b/msgpack-jackson/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
@@ -621,6 +621,11 @@ public class MessagePackParser
         return streamReadContext.getCurrentName();
     }
 
+    // TODO: Uncomment
+    //public boolean isCurrentFieldId() {
+    //    return this.type == Type.INT || this.type == Type.LONG;
+    //}
+
     @Override
     public String getCurrentName()
             throws IOException

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -89,7 +89,7 @@ public class MessagePackDataformatForFieldIdTest
     {
         ObjectMapper mapper = new ObjectMapper(
                     new MessagePackFactory()
-                        .setWriteIntegerKeysAsStringKeys(false)
+                        .setSupportIntegerKeys(true)
                 )
                 .registerModule(new SimpleModule()
                 .addDeserializer(Map.class, new MessagePackMapDeserializer()));

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -50,10 +50,9 @@ public class MessagePackDataformatForFieldIdTest
                 JsonParser parser = deserializationContext.getParser();
                 if (parser instanceof MessagePackParser) {
                     MessagePackParser p = (MessagePackParser) parser;
-                    // TODO: Uncomment
-                    //if (p.isCurrentFieldId()) {
-                    //    return Integer.valueOf(s);
-                    //}
+                    if (p.isCurrentFieldId()) {
+                        return Integer.valueOf(s);
+                    }
                 }
                 return s;
             }

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -61,7 +61,8 @@ public class MessagePackDataformatForFieldIdTest
                     throws IOException
             {
                 JsonParser parser = deserializationContext.getParser();
-                if (parser instanceof MessagePackParser p) {
+                if (parser instanceof MessagePackParser) {
+                    MessagePackParser p = (MessagePackParser) parser;
                     // TODO: Uncomment
                     //if (p.isCurrentFieldId()) {
                     //    return Integer.valueOf(s);

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -15,7 +15,6 @@
 //
 package org.msgpack.jackson.dataformat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -29,20 +28,10 @@ import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import org.junit.Test;
 
@@ -50,13 +39,10 @@ import static org.junit.Assert.assertEquals;
 
 public class MessagePackDataformatForFieldIdTest
 {
-
     static class MessagePackMapDeserializer extends MapDeserializer
     {
-
         public static KeyDeserializer keyDeserializer = new KeyDeserializer()
         {
-
             @Override
             public Object deserializeKey(String s, DeserializationContext deserializationContext)
                     throws IOException
@@ -96,7 +82,7 @@ public class MessagePackDataformatForFieldIdTest
             return new MessagePackMapDeserializer(this, keyDeser, (JsonDeserializer<Object>) valueDeser, valueTypeDeser,
                     nuller, ignorable, includable);
         }
-    }    
+    }
 
     @Test
     public void testMixedKeys()

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -99,7 +99,8 @@ public class MessagePackDataformatForFieldIdTest
     }    
 
     @Test
-    public void mixed()
+    public void testMixedKeys()
+            throws IOException
     {
         ObjectMapper mapper = new ObjectMapper(new MessagePackFactory())
                 .registerModule(new SimpleModule()

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -87,7 +87,10 @@ public class MessagePackDataformatForFieldIdTest
     public void testMixedKeys()
             throws IOException
     {
-        ObjectMapper mapper = new ObjectMapper(new MessagePackFactory())
+        ObjectMapper mapper = new ObjectMapper(
+                    new MessagePackFactory()
+                        .setWriteIntegerKeysAsStringKeys(false)
+                )
                 .registerModule(new SimpleModule()
                 .addDeserializer(Map.class, new MessagePackMapDeserializer()));
 
@@ -99,6 +102,29 @@ public class MessagePackDataformatForFieldIdTest
         Map<Object, Object> deserializedInit = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
 
         Map<Object, Object> expected = new HashMap<>(map);
+        Map<Object, Object> actual = new HashMap<>(deserializedInit);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMixedKeysBackwardsCompatiable()
+            throws IOException
+    {
+        ObjectMapper mapper = new ObjectMapper(new MessagePackFactory())
+                .registerModule(new SimpleModule()
+                .addDeserializer(Map.class, new MessagePackMapDeserializer()));
+
+        Map<Object, Object> map = new HashMap<>();
+        map.put(1, "one");
+        map.put("2", "two");
+
+        byte[] bytes = mapper.writeValueAsBytes(map);
+        Map<Object, Object> deserializedInit = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
+
+        Map<Object, Object> expected = new HashMap<>();
+        expected.put("1", "one");
+        expected.put("2", "two");
         Map<Object, Object> actual = new HashMap<>(deserializedInit);
 
         assertEquals(expected, actual);

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -1,0 +1,115 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.NullValueProvider;
+import com.fasterxml.jackson.databind.deser.impl.JDKValueInstantiators;
+import com.fasterxml.jackson.databind.deser.std.MapDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessagePackDataformatForFieldIdTest
+{
+
+    static class MessagePackMapDeserializer extends MapDeserializer
+    {
+
+        public static KeyDeserializer keyDeserializer = new KeyDeserializer()
+        {
+
+            @Override
+            public Object deserializeKey(String s, DeserializationContext deserializationContext)
+                    throws IOException
+            {
+                JsonParser parser = deserializationContext.getParser();
+                if (parser instanceof MessagePackParser p) {
+                    // TODO: Uncomment
+                    //if (p.isCurrentFieldId()) {
+                    //    return Integer.valueOf(s);
+                    //}
+                }
+                return s;
+            }
+        };
+
+        public MessagePackMapDeserializer()
+        {
+            super(
+                    TypeFactory.defaultInstance().constructMapType(Map.class, Object.class, Object.class),
+                    JDKValueInstantiators.findStdValueInstantiator(null, LinkedHashMap.class),
+                    keyDeserializer, null, null);
+        }
+
+        public MessagePackMapDeserializer(MapDeserializer src, KeyDeserializer keyDeser,
+                JsonDeserializer<Object> valueDeser, TypeDeserializer valueTypeDeser, NullValueProvider nuller,
+                Set<String> ignorable, Set<String> includable)
+        {
+            super(src, keyDeser, valueDeser, valueTypeDeser, nuller, ignorable, includable);
+        }
+
+        @Override
+        protected MapDeserializer withResolved(KeyDeserializer keyDeser, TypeDeserializer valueTypeDeser,
+                JsonDeserializer<?> valueDeser, NullValueProvider nuller, Set<String> ignorable,
+                Set<String> includable)
+        {
+            return new MessagePackMapDeserializer(this, keyDeser, (JsonDeserializer<Object>) valueDeser, valueTypeDeser,
+                    nuller, ignorable, includable);
+        }
+    }    
+
+    @Test
+    public void mixed()
+    {
+        ObjectMapper mapper = new ObjectMapper(new MessagePackFactory())
+                .registerModule(new SimpleModule()
+                .addDeserializer(Map.class, new MessagePackMapDeserializer()));
+
+        Map<Object, Object> map = new HashMap<>();
+        map.put(1, "one");
+        map.put("2", "two");
+
+        byte[] bytes = mapper.writeValueAsBytes(map);
+        Map<Object, Object> deserialized = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
+
+        assertEquals(map, deserialized);
+    }
+}

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -97,8 +97,11 @@ public class MessagePackDataformatForFieldIdTest
         map.put("2", "two");
 
         byte[] bytes = mapper.writeValueAsBytes(map);
-        Map<Object, Object> deserialized = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
+        Map<Object, Object> deserializedInit = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
 
-        assertEquals(map, deserialized);
+        Map<Object, Object> expected = new HashMap<>(map);
+        Map<Object, Object> actual = new HashMap<>(deserializedInit);
+
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
### Background
Jackson core has interfaces for [field ids](https://github.com/FasterXML/jackson-core/blob/e4ac4f85873dc5e9cad8201f4b5b659db03b1f73/src/main/java/com/fasterxml/jackson/core/JsonGenerator.java#L1140-L1157). This is a great opportunity for msgpack, since the protocol allows for integer keys, enabling more advanced binary serialization strategies for further reduced message size.

Current implementation of msgpack-jackson only allows for coercing strings to integers. Implementing the formal interfaces will enable end-to-end map serialization with mixed string/integer keys. [Other msgpack implementations](https://github.com/msgpack/msgpack-python?tab=readme-ov-file#security) already support this.

### Summary of Changes
1. Implement the formal jackson core interface for writing integer keys as field ids instead of strings.
2. Add a helper function on the msgpack parser that can be used in a jackson `KeyDeserializer` to deserialize field ids.