### PR TITLE
Refactor CI to use matrix strategy and add JDK 24 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,75 +27,25 @@ jobs:
       - uses: actions/checkout@v4
       - name: jcheckstyle
         run: ./sbt jcheckStyle
-  test_jdk21:
-    name: Test JDK21
+  
+  test:
+    name: Test JDK${{ matrix.java }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['8', '11', '17', '21', '24']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '21'
+          java-version: ${{ matrix.java }}
       - uses: actions/cache@v4
         with:
           path: ~/.cache
-          key: ${{ runner.os }}-jdk21-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk21-
+          key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
+          restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
       - name: Test
         run: ./sbt test
       - name: Universal Buffer Test
-        run: ./sbt test -J-Dmsgpack.universal-buffer=true
-  test_jdk17:
-    name: Test JDK17
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk17-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk17-
-      - name: Test
-        run: ./sbt test
-      - name: Universal Buffer Test
-        run: ./sbt test -J-Dmsgpack.universal-buffer=true
-  test_jdk11:
-    name: Test JDK11
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '11'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk11-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk11-
-      - name: Test
-        run: ./sbt test
-      - name: Universal Buffer Test
-        run: ./sbt test -J-Dmsgpack.universal-buffer=true
-  test_jdk8:
-    name: Test JDK8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '8'
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache
-          key: ${{ runner.os }}-jdk8-${{ hashFiles('**/*.sbt') }}
-          restore-keys: ${{ runner.os }}-jdk8-
-      - name: Test
-        run: ./sbt test
-      - name: Universal    Buffer Test
         run: ./sbt test -J-Dmsgpack.universal-buffer=true


### PR DESCRIPTION
## Summary
- Refactored CI workflow to use GitHub Actions matrix strategy for JDK testing
- Added JDK 24 to the test matrix
- Reduced CI configuration from ~100 lines to ~50 lines

## Changes
- Replaced 4 individual test jobs (test_jdk8, test_jdk11, test_jdk17, test_jdk21) with a single matrix-based job
- Added JDK 24 to the test matrix, so tests now run on JDK 8, 11, 17, 21, and 24
- Each JDK version still runs both standard tests and universal buffer tests

## Benefits
- Cleaner, more maintainable CI configuration
- Easy to add new JDK versions in the future (just add to the matrix array)
- Reduces duplication and potential for configuration drift
- All JDK versions use identical test steps

## Test plan
- [x] CI workflow syntax is valid
- [ ] All existing JDK versions (8, 11, 17, 21) continue to be tested
- [ ] New JDK 24 tests run successfully
- [ ] Both standard and universal buffer tests run for each JDK version

🤖 Generated with [Claude Code](https://claude.ai/code)