### PR TITLE
Update sbt-dynver to 5.1.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp"      % "2.3.1")
 addSbtPlugin("org.xerial.sbt"   % "sbt-jcheckstyle" % "0.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-osgi"        % "0.10.0")
 addSbtPlugin("org.scalameta"    % "sbt-scalafmt"    % "2.5.4")
-addSbtPlugin("com.github.sbt"     % "sbt-dynver"      % "5.1.0")
+addSbtPlugin("com.github.sbt"     % "sbt-dynver"      % "5.1.1")
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
## Summary
Updates sbt-dynver from 5.1.0 to 5.1.1

## Changes
- Updated `project/plugins.sbt` to use sbt-dynver version 5.1.1

## Notes
This is a patch version update with no breaking changes.

Fixes #892

🤖 Generated with [Claude Code](https://claude.ai/code)