### PR TITLE
Migrate from JUnit 4 to JUnit 5 to resolve deprecation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,8 @@ val buildSettings = Seq[Setting[_]](
   Test / compile := ((Test / compile) dependsOn (Test / jcheckStyle)).value
 )
 
-val junitInterface = "com.github.sbt" % "junit-interface" % "0.13.3" % "test"
+val junitJupiter = "org.junit.jupiter" % "junit-jupiter" % "5.11.4" % "test"
+val junitVintage = "org.junit.vintage" % "junit-vintage-engine" % "5.11.4" % "test"
 
 // Project settings
 lazy val root = Project(id = "msgpack-java", base = file("."))
@@ -83,7 +84,8 @@ lazy val msgpackCore = Project(id = "msgpack-core", base = file("msgpack-core"))
     Test / fork := true,
     libraryDependencies ++= Seq(
       // msgpack-core should have no external dependencies
-      junitInterface,
+      junitJupiter,
+      junitVintage,
       "org.wvlet.airframe" %% "airframe-json" % AIRFRAME_VERSION % "test",
       "org.wvlet.airframe" %% "airspec"       % AIRFRAME_VERSION % "test",
       // Add property testing support with forAll methods
@@ -110,7 +112,8 @@ lazy val msgpackJackson =
       ),
       libraryDependencies ++= Seq(
         "com.fasterxml.jackson.core" % "jackson-databind" % "2.18.2",
-        junitInterface,
+        junitJupiter,
+        junitVintage,
         "org.apache.commons" % "commons-math3" % "3.6.1" % "test"
       ),
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -33,9 +33,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.LinkedHashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MessagePackDataformatForFieldIdTest
 {

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
@@ -16,7 +16,7 @@
 package org.msgpack.jackson.dataformat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -24,9 +24,9 @@ import java.nio.charset.Charset;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.containsString;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MessagePackDataformatForPojoTest
         extends MessagePackDataformatTestBase

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackFactoryTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackFactoryTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 
 import java.io.IOException;
@@ -35,8 +35,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MessagePackFactoryTest
         extends MessagePackDataformatTestBase

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.msgpack.core.ExtensionTypeHeader;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
@@ -53,13 +53,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MessagePackGeneratorTest
         extends MessagePackDataformatTestBase
@@ -349,7 +350,7 @@ public class MessagePackGeneratorTest
         }
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testEnableFeatureAutoCloseTarget()
             throws IOException
     {
@@ -358,7 +359,9 @@ public class MessagePackGeneratorTest
         ObjectMapper objectMapper = new ObjectMapper(messagePackFactory);
         List<Integer> integers = Arrays.asList(1);
         objectMapper.writeValue(out, integers);
-        objectMapper.writeValue(out, integers);
+        assertThrows(IOException.class, () -> {
+            objectMapper.writeValue(out, integers);
+        });
     }
 
     @Test

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackMapperTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackMapperTest.java
@@ -16,14 +16,14 @@
 package org.msgpack.jackson.dataformat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MessagePackMapperTest
 {

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.value.ExtensionValue;
@@ -52,10 +52,11 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MessagePackParserTest
         extends MessagePackDataformatTestBase
@@ -450,7 +451,7 @@ public class MessagePackParserTest
         return tempFile;
     }
 
-    @Test(expected = IOException.class)
+    @Test
     public void testEnableFeatureAutoCloseSource()
             throws Exception
     {
@@ -459,7 +460,9 @@ public class MessagePackParserTest
         FileInputStream in = new FileInputStream(tempFile);
         ObjectMapper objectMapper = new ObjectMapper(factory);
         objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
-        objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
+        assertThrows(IOException.class, () -> {
+            objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
+        });
     }
 
     @Test

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/TimestampExtensionModuleTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/TimestampExtensionModuleTest.java
@@ -16,8 +16,8 @@
 package org.msgpack.jackson.dataformat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
 import org.msgpack.core.MessageUnpacker;
@@ -26,7 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TimestampExtensionModuleTest
 {
@@ -46,7 +46,7 @@ public class TimestampExtensionModuleTest
         public Instant c;
     }
 
-    @Before
+    @BeforeEach
     public void setUp()
             throws Exception
     {

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/benchmark/MessagePackDataformatHugeDataBenchmarkTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/benchmark/MessagePackDataformatHugeDataBenchmarkTest.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 
 import java.io.File;

--- a/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/benchmark/MessagePackDataformatPojoBenchmarkTest.java
+++ b/msgpack-jackson/src/test/java/org/msgpack/jackson/dataformat/benchmark/MessagePackDataformatPojoBenchmarkTest.java
@@ -17,7 +17,7 @@ package org.msgpack.jackson.dataformat.benchmark;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 import static org.msgpack.jackson.dataformat.MessagePackDataformatTestBase.NormalPojo;
 import static org.msgpack.jackson.dataformat.MessagePackDataformatTestBase.Suit;


### PR DESCRIPTION
## Summary
- Migrates msgpack-jackson tests from JUnit 4 to JUnit 5
- Resolves all JUnit deprecation warnings
- Maintains test functionality and backward compatibility

## Changes Made
- **Dependencies**: Updated `build.sbt` to use JUnit 5 Jupiter and Vintage engines
- **Imports**: Replaced JUnit 4 imports with JUnit 5 equivalents
- **Annotations**: 
  - `@Test` → `@Test` (JUnit 5)
  - `@Before` → `@BeforeEach`
  - `@Test(expected=Exception.class)` → `assertThrows(Exception.class, () -> {...})`
- **Assertions**: Replaced deprecated `org.junit.Assert.assertThat` with `org.hamcrest.MatcherAssert.assertThat`

## Test Results
✅ All tests pass successfully
✅ No more JUnit deprecation warnings
✅ Compilation successful

## Backward Compatibility
The JUnit Vintage engine is included to maintain compatibility with any remaining JUnit 4 tests.

🤖 Generated with [Claude Code](https://claude.ai/code)