### PR TITLE
Skip CI tests for non-code changes using dorny/paths-filter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,27 +2,42 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.github/workflows/**.yml'
-      - 'project/build.properties'
   push:
     branches:
       - main
-    paths:
-      - '**.scala'
-      - '**.java'
-      - '**.sbt'
-      - '.github/workflows/**.yml'
-      - 'project/build.properties'
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.changes.outputs.code }}
+      docs: ${{ steps.changes.outputs.docs }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            code:
+              - '**.scala'
+              - '**.java'
+              - '**.sbt'
+              - '.github/workflows/**.yml'
+              - 'project/build.properties'
+              - 'msgpack-core/**'
+              - 'msgpack-jackson/**'
+            docs:
+              - '**.md'
+              - '**.txt'
+              - 'LICENSE'
+
   code_format:
     name: Code Format
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: jcheckstyle
@@ -31,6 +46,8 @@ jobs:
   test:
     name: Test JDK${{ matrix.java }}
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     strategy:
       matrix:
         java: ['8', '11', '17', '21', '24']


### PR DESCRIPTION
## Summary
- Implements dorny/paths-filter to conditionally skip CI tests based on file changes
- Adds a `changes` job that detects whether code or documentation files were modified
- Updates `code_format` and `test` jobs to only run when code changes are detected
- Improves CI efficiency by skipping expensive test matrix when only documentation is updated

## Benefits
- Faster CI runs for documentation-only PRs
- Reduced resource usage and costs
- Maintains all existing functionality for code changes

## Test plan
- [ ] Verify CI runs normally for code changes
- [ ] Verify CI skips tests for documentation-only changes
- [ ] Test with mixed changes (code + docs)

🤖 Generated with [Claude Code](https://claude.ai/code)