### PR TITLE
Add scalafmtCheckAll to code format CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: jcheckstyle
         run: ./sbt jcheckStyle
+      - name: scalafmtCheckAll
+        run: ./sbt scalafmtCheckAll
   
   test:
     name: Test JDK${{ matrix.java }}


### PR DESCRIPTION
## Summary
- Adds `scalafmtCheckAll` step to the code_format CI job
- Ensures Scala code formatting is validated alongside Java checkstyle
- Maintains consistency with project's code formatting standards

## Test plan
- [x] Verified `scalafmtCheckAll` command runs successfully locally
- [x] CI will validate the formatting check works properly

🤖 Generated with [Claude Code](https://claude.ai/code)