### PR TITLE
Fix: Remove sun and android.os packages from Import-Package header of…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,11 @@ lazy val msgpackCore = Project(id = "msgpack-core", base = file("msgpack-core"))
         "org.msgpack.value",
         "org.msgpack.value.impl"
       ),
+	OsgiKeys.importPackage :=
+	  Seq(
+        "!android.os",
+        "!sun.*"
+      ),
     testFrameworks += new TestFramework("wvlet.airspec.Framework"),
     Test / javaOptions ++=
       Seq(


### PR DESCRIPTION
* Make sure that there will be no android.os nor a sun.* Import-Package entry in the MANIFEST.MF file.
* This fixes a problem when including the library in an OSGi environment that is outside of the Anroid universe - notice also that the sun packages are not needed in OSGi neither.
