### PR TITLE
Update junit-vintage-engine to 5.14.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,7 +97,7 @@ val buildSettings = Seq[Setting[?]](
 )
 
 val junitJupiter = "org.junit.jupiter" % "junit-jupiter"        % "5.14.4" % "test"
-val junitVintage = "org.junit.vintage" % "junit-vintage-engine" % "5.14.1" % "test"
+val junitVintage = "org.junit.vintage" % "junit-vintage-engine" % "5.14.4" % "test"
 
 // Project settings
 lazy val root = Project(id = "msgpack-java", base = file("."))


### PR DESCRIPTION
## Summary
- Aligns `junit-vintage-engine` with the `junit-jupiter` 5.14.4 update merged in #969.
- Supersedes #970 (which had a merge conflict against main).

## Test plan
- [x] CI passes on all JDK versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)