### PR TITLE
Add auto-merge workflow for Dependabot and Scala Steward PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,14 +24,3 @@ jobs:
         run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  auto-merge-scala-steward:
-    name: Auto-Merge Scala Steward PRs
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'scala-steward' }}
-    steps:
-      - name: Enable auto-merge for non-major updates
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'semver-major') }}
-        run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,3 +24,18 @@ jobs:
         run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge-scala-steward:
+    name: Auto-Merge Scala Steward PRs
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'scala-steward' }}
+    steps:
+      # Skip auto-merge if the PR carries a semver-major label. Note: this repo
+      # does not yet apply semver labels to Scala Steward PRs, so this guard is
+      # a no-op until early-semver-* labels are added to the repo and Scala
+      # Steward is configured to apply them.
+      - name: Enable auto-merge for non-major updates
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'semver-major') && !contains(github.event.pull_request.labels.*.name, 'early-semver-major') }}
+        run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,37 @@
+name: auto-merge
+# pull_request_target runs in the base-branch context, which is required so
+# that GITHUB_TOKEN gets the write permissions declared below even for PRs
+# opened by Dependabot (which would otherwise receive a read-only token on
+# regular pull_request events). This workflow never checks out PR head code,
+# so the usual pull_request_target injection risk does not apply.
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge-dependabot:
+    name: Auto-Merge Dependabot PRs
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+      - name: Enable auto-merge for non-major updates
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-merge-scala-steward:
+    name: Auto-Merge Scala Steward PRs
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'scala-steward' }}
+    steps:
+      - name: Enable auto-merge for non-major updates
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'semver-major') }}
+        run: gh pr merge --squash --auto "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plans/2026-05-05-auto-merge.md
+++ b/plans/2026-05-05-auto-merge.md
@@ -35,32 +35,38 @@ pattern used in `wvlet/uni/.github/workflows/auto-merge.yml`.
 
 ## Plan
 
-1. Add `.github/workflows/auto-merge.yml` with one job:
+1. Add `.github/workflows/auto-merge.yml` with two jobs:
    - **auto-merge-dependabot**: triggers when
      `github.event.pull_request.user.login == 'dependabot[bot]'`, uses
      `dependabot/fetch-metadata@v2` to read the update type, and runs
      `gh pr merge --squash --auto` only when the update is **not**
      `version-update:semver-major`.
+   - **auto-merge-scala-steward**: triggers when
+     `github.event.pull_request.user.login == 'scala-steward'` and
+     auto-merges unless the PR carries a `semver-major` or
+     `early-semver-major` label.
 2. Set workflow-level `permissions` to the minimum required:
    `contents: write` and `pull-requests: write`.
 3. Use `GITHUB_TOKEN` directly via `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
 
-### Scala Steward (deferred)
+### Scala Steward label caveat
 
-The initial draft also auto-merged Scala Steward PRs, gated on a
-`semver-major` label being absent. But this repo's existing Scala Steward PRs
-only carry `library-update` (and sometimes `internal`) — no semver labels are
-configured, so a `!contains(..., 'semver-major')` guard is effectively a
-no-op and would auto-merge every Scala Steward PR including major bumps.
-Codex review caught this. Rather than ship an unsafe guard, we drop the
-Scala Steward job from this PR. Re-adding it should be a follow-up that
-either:
-- Defines `early-semver-major`/`early-semver-minor`/`early-semver-patch`
-  labels in the repo (Scala Steward only applies labels that already exist)
-  and adds a `.scala-steward.conf` enabling them, then guards on
-  `early-semver-major`.
-- Or uses a manual opt-in label like `auto-merge` that the maintainer adds
-  after a quick review.
+This repo's current Scala Steward PRs only carry `library-update` (and
+sometimes `internal`) — no semver labels are configured upstream, so the
+`semver-major` / `early-semver-major` guard is effectively a no-op until:
+- The labels are added to the repo (Scala Steward only applies labels that
+  already exist), and
+- Scala Steward is configured (e.g. via `.scala-steward.conf`) to attach
+  them.
+
+This matches the same caveat in the wvlet/uni reference implementation,
+which uses `semver-spec-major` against `github.event.issue.labels` (not even
+the right field on a PR event) — so its guard is also effectively a no-op
+in practice. We accept the same trade-off here: most Scala Steward PRs are
+patch/minor library updates, CI runs across JDK 8/11/17/21/24 and will fail
+the merge-readiness checks if anything regresses, and a major bump that
+slips through can be reverted. A follow-up could tighten this by setting up
+proper semver labels.
 
 ## Out of scope
 
@@ -68,7 +74,7 @@ either:
 - Auto-approving PRs (a human approval may still be required by branch
   protection — auto-merge will simply wait for it).
 - Changing branch protection rules.
-- Scala Steward auto-merge (see above).
+- Configuring Scala Steward to apply semver labels (see caveat above).
 
 ## Validation
 

--- a/plans/2026-05-05-auto-merge.md
+++ b/plans/2026-05-05-auto-merge.md
@@ -35,20 +35,32 @@ pattern used in `wvlet/uni/.github/workflows/auto-merge.yml`.
 
 ## Plan
 
-1. Add `.github/workflows/auto-merge.yml` with two jobs:
-   - **auto-merge-dependabot**: triggers when `github.actor == 'dependabot[bot]'`,
-     uses `dependabot/fetch-metadata@v3` to read the update type, and runs
+1. Add `.github/workflows/auto-merge.yml` with one job:
+   - **auto-merge-dependabot**: triggers when
+     `github.event.pull_request.user.login == 'dependabot[bot]'`, uses
+     `dependabot/fetch-metadata@v2` to read the update type, and runs
      `gh pr merge --squash --auto` only when the update is **not**
      `version-update:semver-major`.
-   - **auto-merge-scala-steward**: triggers when `github.actor == 'scala-steward'`
-     and runs `gh pr merge --squash --auto` for all such PRs (Scala Steward
-     does not surface a structured "major" signal the way Dependabot's
-     fetch-metadata action does, so we rely on Scala Steward's own
-     `pullRequests.allowedUpdates` config — already filtered upstream — and
-     skip if the PR has a `semver-major` label).
 2. Set workflow-level `permissions` to the minimum required:
    `contents: write` and `pull-requests: write`.
 3. Use `GITHUB_TOKEN` directly via `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
+
+### Scala Steward (deferred)
+
+The initial draft also auto-merged Scala Steward PRs, gated on a
+`semver-major` label being absent. But this repo's existing Scala Steward PRs
+only carry `library-update` (and sometimes `internal`) — no semver labels are
+configured, so a `!contains(..., 'semver-major')` guard is effectively a
+no-op and would auto-merge every Scala Steward PR including major bumps.
+Codex review caught this. Rather than ship an unsafe guard, we drop the
+Scala Steward job from this PR. Re-adding it should be a follow-up that
+either:
+- Defines `early-semver-major`/`early-semver-minor`/`early-semver-patch`
+  labels in the repo (Scala Steward only applies labels that already exist)
+  and adds a `.scala-steward.conf` enabling them, then guards on
+  `early-semver-major`.
+- Or uses a manual opt-in label like `auto-merge` that the maintainer adds
+  after a quick review.
 
 ## Out of scope
 
@@ -56,6 +68,7 @@ pattern used in `wvlet/uni/.github/workflows/auto-merge.yml`.
 - Auto-approving PRs (a human approval may still be required by branch
   protection — auto-merge will simply wait for it).
 - Changing branch protection rules.
+- Scala Steward auto-merge (see above).
 
 ## Validation
 

--- a/plans/2026-05-05-auto-merge.md
+++ b/plans/2026-05-05-auto-merge.md
@@ -1,0 +1,65 @@
+# Add auto-merge GitHub Actions workflow
+
+## Goal
+
+Add a workflow that automatically enables auto-merge on PRs from trusted bots
+(Dependabot and Scala Steward) for non-major version bumps, mirroring the
+pattern used in `wvlet/uni/.github/workflows/auto-merge.yml`.
+
+## Context
+
+- Recent PR history shows the repo regularly receives many bot PRs:
+  - `dependabot[bot]` — for GitHub Actions version bumps
+  - `scala-steward` — for Scala/sbt/Java library updates
+- These currently require manual merge from the maintainer.
+- Repo settings already allow auto-merge (`allow_auto_merge: true`) and squash
+  is the default merge method.
+- CI passes branch-protection checks on PRs; once a PR is approved and CI is
+  green, GitHub will merge it automatically.
+
+## Differences from wvlet/uni
+
+- **No GitHub App token.** wvlet/uni uses a GitHub App (`APP_ID` +
+  `APP_PRIVATE_KEY`) to bypass the read-only `GITHUB_TOKEN` that GitHub
+  hands to `pull_request` workflows triggered by Dependabot. msgpack/msgpack-java
+  doesn't have that App configured, so this workflow uses
+  `on: pull_request_target` instead — that event runs in the base-branch
+  context where the workflow's declared `permissions:` block actually grants
+  write access to `GITHUB_TOKEN`. We never check out PR head code, so the
+  usual `pull_request_target` injection risk does not apply.
+- **Scala Steward actor is `scala-steward`**, not wvlet/uni's
+  `scala-steward-wvlet[bot]` or `xerial-bot` (visible in `gh pr list`).
+- **Filter on `github.event.pull_request.user.login`**, not `github.actor`,
+  because under `pull_request_target` the latter can resolve to the merger
+  rather than the PR author.
+
+## Plan
+
+1. Add `.github/workflows/auto-merge.yml` with two jobs:
+   - **auto-merge-dependabot**: triggers when `github.actor == 'dependabot[bot]'`,
+     uses `dependabot/fetch-metadata@v3` to read the update type, and runs
+     `gh pr merge --squash --auto` only when the update is **not**
+     `version-update:semver-major`.
+   - **auto-merge-scala-steward**: triggers when `github.actor == 'scala-steward'`
+     and runs `gh pr merge --squash --auto` for all such PRs (Scala Steward
+     does not surface a structured "major" signal the way Dependabot's
+     fetch-metadata action does, so we rely on Scala Steward's own
+     `pullRequests.allowedUpdates` config — already filtered upstream — and
+     skip if the PR has a `semver-major` label).
+2. Set workflow-level `permissions` to the minimum required:
+   `contents: write` and `pull-requests: write`.
+3. Use `GITHUB_TOKEN` directly via `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
+
+## Out of scope
+
+- Setting up a GitHub App for elevated bot identity.
+- Auto-approving PRs (a human approval may still be required by branch
+  protection — auto-merge will simply wait for it).
+- Changing branch protection rules.
+
+## Validation
+
+- Lint the YAML by checking the file parses (visual review + actionlint if
+  available).
+- After merge, watch the next dependabot/scala-steward PR to confirm
+  auto-merge gets enabled.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-merge.yml` with two jobs that enable squash auto-merge on PRs from `dependabot[bot]` and `scala-steward`. Modeled on `wvlet/uni/.github/workflows/auto-merge.yml`.
- Uses `on: pull_request_target` instead of `pull_request` so the declared `permissions:` block grants `GITHUB_TOKEN` actual write access on Dependabot-authored runs (without needing a GitHub App). The workflow never checks out PR head code, so the standard `pull_request_target` injection risk does not apply.
- Dependabot job uses `dependabot/fetch-metadata` to detect and skip `version-update:semver-major`.
- Scala Steward job skips PRs labeled `semver-major` or `early-semver-major`.

Plan: `plans/2026-05-05-auto-merge.md`.

## Scala Steward label caveat

The repo doesn't currently apply semver labels to Scala Steward PRs (only `library-update`), so the `semver-major` / `early-semver-major` guard is effectively a no-op for now. This matches wvlet/uni's behavior — its guard checks `github.event.issue.labels` which doesn't exist on PR events, so it's also a no-op there. A follow-up can tighten this by adding the labels to the repo and configuring Scala Steward to apply them. Risk is acceptable in the meantime: CI runs across JDK 8/11/17/21/24 and a slipped-through major bump can be reverted.

## Prereqs

- Repo already has "Allow auto-merge" enabled (`allow_auto_merge: true`) and squash is the default merge method.
- GitHub will only merge once required status checks pass and any required reviewers approve — auto-merge does not bypass branch protection.

## Test plan

- [ ] Workflow YAML parses cleanly (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] After merge, observe the next Dependabot or Scala Steward PR: workflow run should succeed and the PR should show "auto-merge enabled by github-actions[bot]".
- [ ] Confirm a major-version Dependabot PR does NOT get auto-merge enabled (the `version-update:semver-major` guard).