### PR TITLE
Add module name to the package manifest attributes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,6 @@ ThisBuild / scmInfo  :=
     )
   )
 
-ThisBuild / packageOptions += Package.ManifestAttributes(
-  "Automatic-Module-Name" -> s"${OsgiKeys.bundleSymbolicName}"
-)
-
 ThisBuild / developers :=
   List(
     Developer(
@@ -130,6 +126,9 @@ lazy val msgpackCore = Project(id = "msgpack-core", base = file("msgpack-core"))
         "org.msgpack.value.impl"
       ),
     OsgiKeys.importPackage := Seq("!android.os", "!sun.*"),
+    packageOptions += Package.ManifestAttributes(
+      "Automatic-Module-Name" -> OsgiKeys.exportPackage.value.head
+    ),
     testFrameworks += new TestFramework("wvlet.airspec.Framework"),
     Test / javaOptions ++=
       Seq(
@@ -164,6 +163,9 @@ lazy val msgpackJackson = Project(id = "msgpack-jackson", base = file("msgpack-j
     description                 := "Jackson extension that adds support for MessagePack",
     OsgiKeys.bundleSymbolicName := "org.msgpack.msgpack-jackson",
     OsgiKeys.exportPackage      := Seq("org.msgpack.jackson", "org.msgpack.jackson.dataformat"),
+    packageOptions += Package.ManifestAttributes(
+      "Automatic-Module-Name" -> OsgiKeys.exportPackage.value.head
+    ),
     libraryDependencies ++=
       Seq(
         "com.fasterxml.jackson.core" % "jackson-databind" % "2.20.0",

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,10 @@ ThisBuild / scmInfo  :=
     )
   )
 
+ThisBuild / packageOptions += Package.ManifestAttributes(
+  "Automatic-Module-Name" -> s"${OsgiKeys.bundleSymbolicName}"
+)
+
 ThisBuild / developers :=
   List(
     Developer(


### PR DESCRIPTION
I tried pulling `msgpack-core` in through Maven, and I noticed that the module name was being parsed from the jar file name as `msgpack.core` instead of `org.msgpack.core`. This change adds the module name defined in the sbt config to the package manifest attributes so that Maven autodetects the correct name.