### PR TITLE
Add msgpack-jackson3 module for Jackson 3.x support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,7 @@ jobs:
               - 'project/build.properties'
               - 'msgpack-core/**'
               - 'msgpack-jackson/**'
+              - 'msgpack-jackson3/**'
             docs:
               - '**.md'
               - '**.txt'
@@ -65,6 +66,16 @@ jobs:
           key: ${{ runner.os }}-jdk${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}
           restore-keys: ${{ runner.os }}-jdk${{ matrix.java }}-
       - name: Test
-        run: ./sbt test
+        run: |
+          if [[ ${{ matrix.java }} -lt 17 ]]; then
+            ./sbt msgpack-core/test msgpack-jackson/test
+          else
+            ./sbt test
+          fi
       - name: Universal Buffer Test
-        run: ./sbt test -J-Dmsgpack.universal-buffer=true
+        run: |
+          if [[ ${{ matrix.java }} -lt 17 ]]; then
+            ./sbt msgpack-core/test msgpack-jackson/test -J-Dmsgpack.universal-buffer=true
+          else
+            ./sbt test -J-Dmsgpack.universal-buffer=true
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,17 @@ jobs:
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         run: |
-          ./sbt publishSigned
+          ./sbt msgpack-core/publishSigned msgpack-jackson/publishSigned
+      # msgpack-jackson3 requires JDK 17+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Build bundle for msgpack-jackson3
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: |
+          ./sbt msgpack-jackson3/publishSigned
       - name: Release to Sonatype
         env:
           SONATYPE_USERNAME: '${{ secrets.SONATYPE_USERNAME }}'

--- a/README.md
+++ b/README.md
@@ -53,8 +53,16 @@ For using DirectByteBuffer (off-heap memory access methods) in JDK17, you need t
 
 ### Integration with Jackson ObjectMapper (jackson-databind)
 
-msgpack-java supports serialization and deserialization of Java objects through [jackson-databind](https://github.com/FasterXML/jackson-databind).
-For details, see [msgpack-jackson/README.md](https://github.com/msgpack/msgpack-java/blob/develop/msgpack-jackson/README.md). The template-based serialization mechanism used in v06 is deprecated.
+msgpack-java supports serialization and deserialization of Java objects through [jackson-databind](https://github.com/FasterXML/jackson-databind). The template-based serialization mechanism used in v06 is deprecated.
+
+Two artifacts are published depending on which Jackson major version your project uses:
+
+| Jackson version | Artifact | Requirements |
+| --- | --- | --- |
+| Jackson 2.x | [`jackson-dataformat-msgpack`](https://github.com/msgpack/msgpack-java/blob/develop/msgpack-jackson/README.md) | Java 8+ |
+| Jackson 3.x | [`jackson-dataformat-msgpack-jackson3`](https://github.com/msgpack/msgpack-java/blob/develop/msgpack-jackson3/README.md) | Java 17+ |
+
+Use `jackson-dataformat-msgpack` if your project still depends on Jackson 2.x, or `jackson-dataformat-msgpack-jackson3` if you've upgraded to Jackson 3.x. See each module's README for install instructions and usage details.
 
 - [Release Notes](https://github.com/msgpack/msgpack-java/blob/develop/RELEASE_NOTES.md)
 

--- a/build.sbt
+++ b/build.sbt
@@ -96,10 +96,18 @@ val buildSettings = Seq[Setting[?]](
   Test / compile    := ((Test / compile) dependsOn (Test / jcheckStyle)).value
 )
 
-val junitJupiter = "org.junit.jupiter" % "junit-jupiter"        % "5.14.4" % "test"
-val junitVintage = "org.junit.vintage" % "junit-vintage-engine" % "5.14.4" % "test"
+val junitJupiter   = "org.junit.jupiter" % "junit-jupiter"        % "5.14.4" % "test"
+val junitVintage   = "org.junit.vintage" % "junit-vintage-engine" % "5.14.4" % "test"
+val junitInterface = "com.github.sbt"    % "junit-interface"      % "0.13.3" % "test"
 
 // Project settings
+val isJava17Plus: Boolean = {
+  val v = sys.props.getOrElse("java.specification.version", "1.8")
+  // getOrElse(false): non-numeric versions (e.g. early-access "17-ea") fail safe
+  // by not compiling the jackson3 module rather than making an optimistic guess.
+  if (v.startsWith("1.")) false else scala.util.Try(v.toInt >= 17).getOrElse(false)
+}
+
 lazy val root = Project(id = "msgpack-java", base = file("."))
   .settings(
     buildSettings,
@@ -108,7 +116,10 @@ lazy val root = Project(id = "msgpack-java", base = file("."))
     publish         := {},
     publishLocal    := {}
   )
-  .aggregate(msgpackCore, msgpackJackson)
+  .aggregate(
+    Seq[ProjectReference](msgpackCore, msgpackJackson) ++
+      (if (isJava17Plus) Seq[ProjectReference](msgpackJackson3) else Nil): _*
+  )
 
 lazy val msgpackCore = Project(id = "msgpack-core", base = file("msgpack-core"))
   .enablePlugins(SbtOsgi)
@@ -168,5 +179,30 @@ lazy val msgpackJackson = Project(id = "msgpack-jackson", base = file("msgpack-j
         "org.apache.commons" % "commons-math3" % "3.6.1" % "test"
       ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
+  )
+  .dependsOn(msgpackCore)
+
+lazy val msgpackJackson3 = Project(id = "msgpack-jackson3", base = file("msgpack-jackson3"))
+  .enablePlugins(SbtOsgi, JmhPlugin)
+  .settings(
+    buildSettings,
+    name                        := "jackson-dataformat-msgpack-jackson3",
+    description                 := "Jackson 3.x extension that adds support for MessagePack",
+    OsgiKeys.bundleSymbolicName := "org.msgpack.msgpack-jackson3",
+    OsgiKeys.exportPackage      := Seq("org.msgpack.jackson", "org.msgpack.jackson.dataformat"),
+    OsgiKeys.importPackage      := Seq("!android.os", "!sun.*"),
+    Test / fork    := true,
+    javacOptions   := Seq("--release", "17"),
+    doc / javacOptions := Seq("--release", "17", "-Xdoclint:none"),
+    libraryDependencies ++=
+      Seq(
+        "tools.jackson.core" % "jackson-databind" % "3.1.2",
+        junitInterface
+      ),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
+    Jmh / javaOptions ++= Seq(
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"
+    )
   )
   .dependsOn(msgpackCore)

--- a/msgpack-jackson3/README.md
+++ b/msgpack-jackson3/README.md
@@ -1,0 +1,480 @@
+# jackson-dataformat-msgpack-jackson3
+
+This Jackson 3.x extension library is a component to easily read and write [MessagePack](http://msgpack.org/) encoded data through jackson-databind API.
+
+It extends standard Jackson streaming API (`JsonFactory`, `JsonParser`, `JsonGenerator`), and as such works seamlessly with all the higher level data abstractions (data binding, tree model, and pluggable extensions).
+
+**Requirements:** Java 17+ and Jackson 3.x. For the Jackson 2.x compatible version, see [`msgpack-jackson`](../msgpack-jackson/).
+
+**Note on imports:** Jackson 3 moved its core and databind packages from `com.fasterxml.jackson` to `tools.jackson`. User-facing annotations (`@JsonProperty`, `@JsonFormat`, etc.) remain in `com.fasterxml.jackson.annotation` for backward compatibility.
+
+## Install
+
+### Maven
+
+```xml
+<dependency>
+  <groupId>org.msgpack</groupId>
+  <artifactId>jackson-dataformat-msgpack-jackson3</artifactId>
+  <version>(version)</version>
+</dependency>
+```
+
+### Sbt
+
+```scala
+libraryDependencies += "org.msgpack" % "jackson-dataformat-msgpack-jackson3" % "(version)"
+```
+
+### Gradle
+
+```groovy
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.msgpack:jackson-dataformat-msgpack-jackson3:(version)'
+}
+```
+
+## Basic usage
+
+### Serialization/Deserialization of POJO
+
+Only thing you need to do is to instantiate `MessagePackFactory` and pass it to the constructor of `tools.jackson.databind.ObjectMapper`. And then, you can use it for MessagePack format data in the same way as jackson-databind.
+
+```java
+// Instantiate ObjectMapper for MessagePack
+ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
+
+// Serialize a Java object to byte array
+ExamplePojo pojo = new ExamplePojo("komamitsu");
+byte[] bytes = objectMapper.writeValueAsBytes(pojo);
+
+// Deserialize the byte array to a Java object
+ExamplePojo deserialized = objectMapper.readValue(bytes, ExamplePojo.class);
+System.out.println(deserialized.getName()); // => komamitsu
+```
+
+Or more easily:
+
+```java
+ObjectMapper objectMapper = new MessagePackMapper();
+```
+
+We strongly recommend calling `MessagePackMapper.Builder#handleBigIntegerAndBigDecimalAsString()` if you serialize and/or deserialize BigInteger/BigDecimal values. See [Serialize and deserialize BigDecimal as str type internally in MessagePack format](#serialize-and-deserialize-bigdecimal-as-str-type-internally-in-messagepack-format) for details.
+
+```java
+ObjectMapper objectMapper = MessagePackMapper.builder().handleBigIntegerAndBigDecimalAsString().build();
+```
+
+### Serialization/Deserialization of List
+
+```java
+// Instantiate ObjectMapper for MessagePack
+ObjectMapper objectMapper = new MessagePackMapper();
+
+// Serialize a List to byte array
+List<Object> list = new ArrayList<>();
+list.add("Foo");
+list.add("Bar");
+list.add(42);
+byte[] bytes = objectMapper.writeValueAsBytes(list);
+
+// Deserialize the byte array to a List
+List<Object> deserialized = objectMapper.readValue(bytes, new TypeReference<List<Object>>() {});
+System.out.println(deserialized); // => [Foo, Bar, 42]
+```
+
+### Serialization/Deserialization of Map
+
+```java
+// Instantiate ObjectMapper for MessagePack
+ObjectMapper objectMapper = new MessagePackMapper();
+
+// Serialize a Map to byte array
+Map<String, Object> map = new HashMap<>();
+map.put("name", "komamitsu");
+map.put("age", 42);
+byte[] bytes = objectMapper.writeValueAsBytes(map);
+
+// Deserialize the byte array to a Map
+Map<String, Object> deserialized = objectMapper.readValue(bytes, new TypeReference<Map<String, Object>>() {});
+System.out.println(deserialized); // => {name=komamitsu, age=42}
+```
+
+### Example of Serialization/Deserialization over multiple languages
+
+Java
+
+```java
+// Serialize
+Map<String, Object> obj = new HashMap<String, Object>();
+obj.put("foo", "hello");
+obj.put("bar", "world");
+byte[] bs = objectMapper.writeValueAsBytes(obj);
+// bs => [-126, -93, 102, 111, 111, -91, 104, 101, 108, 108, 111,
+//        -93, 98, 97, 114, -91, 119, 111, 114, 108, 100]
+```
+
+Ruby
+
+```ruby
+require 'msgpack'
+
+# Deserialize
+xs = [-126, -93, 102, 111, 111, -91, 104, 101, 108, 108, 111,
+      -93, 98, 97, 114, -91, 119, 111, 114, 108, 100]
+MessagePack.unpack(xs.pack("C*"))
+# => {"foo"=>"hello", "bar"=>"world"}
+
+# Serialize
+["zero", 1, 2.0, nil].to_msgpack.unpack('C*')
+# => [148, 164, 122, 101, 114, 111, 1, 203, 64, 0, 0, 0, 0, 0, 0, 0, 192]
+```
+
+Java
+
+```java
+// Deserialize
+bs = new byte[] {(byte) 148, (byte) 164, 122, 101, 114, 111, 1,
+                 (byte) 203, 64, 0, 0, 0, 0, 0, 0, 0, (byte) 192};
+TypeReference<List<Object>> typeReference = new TypeReference<List<Object>>(){};
+List<Object> xs = objectMapper.readValue(bs, typeReference);
+// xs => [zero, 1, 2.0, null]
+```
+
+## Advanced usage
+
+### Serialize multiple values without closing an output stream
+
+`tools.jackson.databind.ObjectMapper` closes an output stream by default after it writes a value. If you want to serialize multiple values in a row without closing an output stream, disable `StreamWriteFeature.AUTO_CLOSE_TARGET`.
+
+```java
+OutputStream out = new FileOutputStream(tempFile);
+ObjectMapper objectMapper = MessagePackMapper.builder()
+        .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+        .build();
+
+objectMapper.writeValue(out, 1);
+objectMapper.writeValue(out, "two");
+objectMapper.writeValue(out, 3.14);
+out.close();
+
+MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(new FileInputStream(tempFile));
+System.out.println(unpacker.unpackInt());      // => 1
+System.out.println(unpacker.unpackString());   // => two
+System.out.println(unpacker.unpackFloat());    // => 3.14
+```
+
+### Deserialize multiple values without closing an input stream
+
+`tools.jackson.databind.ObjectMapper` closes an input stream by default after it reads a value. If you want to deserialize multiple values in a row without closing an input stream, disable `StreamReadFeature.AUTO_CLOSE_SOURCE`.
+
+```java
+MessagePacker packer = MessagePack.newDefaultPacker(new FileOutputStream(tempFile));
+packer.packInt(42);
+packer.packString("Hello");
+packer.close();
+
+FileInputStream in = new FileInputStream(tempFile);
+ObjectMapper objectMapper = MessagePackMapper.builder()
+        .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+        .build();
+System.out.println(objectMapper.readValue(in, Integer.class));
+System.out.println(objectMapper.readValue(in, String.class));
+in.close();
+```
+
+### Serialize not using str8 type
+
+Old msgpack-java (e.g 0.6.7) doesn't support MessagePack str8 type. When your application needs to communicate with such an old MessagePack library, you can disable the data type like this:
+
+```java
+MessagePack.PackerConfig config = new MessagePack.PackerConfig().withStr8FormatSupport(false);
+ObjectMapper objectMapper = new MessagePackMapper(new MessagePackFactory(config));
+// This string is serialized as bin8 type
+byte[] resultWithoutStr8Format = objectMapper.writeValueAsBytes(str8LengthString);
+```
+
+### Serialize using non-String as a key of Map
+
+When you want to use non-String value as a key of Map, use `MessagePackKeySerializer` for key serialization.
+
+```java
+@JsonSerialize(keyUsing = MessagePackKeySerializer.class)
+private Map<Integer, String> intMap = new HashMap<>();
+
+  :
+
+intMap.put(42, "Hello");
+
+ObjectMapper objectMapper = new MessagePackMapper();
+byte[] bytes = objectMapper.writeValueAsBytes(intMap);
+
+Map<Integer, String> deserialized = objectMapper.readValue(bytes, new TypeReference<Map<Integer, String>>() {});
+System.out.println(deserialized);   // => {42=Hello}
+```
+
+### Serialize and deserialize BigDecimal as str type internally in MessagePack format
+
+`jackson-dataformat-msgpack-jackson3` represents BigDecimal values as float type in MessagePack format by default for backward compatibility. But the default behavior could fail when handling too large value for `double` type. So we strongly recommend calling `MessagePackMapper.Builder#handleBigIntegerAndBigDecimalAsString()` to internally handle BigDecimal values as String.
+
+```java
+ObjectMapper objectMapper = MessagePackMapper.builder().handleBigIntegerAndBigDecimalAsString().build();
+
+Pojo obj = new Pojo();
+// This value is too large to be serialized as double
+obj.value = new BigDecimal("1234567890.98765432100");
+
+byte[] converted = objectMapper.writeValueAsBytes(obj);
+
+System.out.println(objectMapper.readValue(converted, Pojo.class));   // => Pojo{value=1234567890.98765432100}
+```
+
+`MessagePackMapper.Builder#handleBigIntegerAndBigDecimalAsString()` is equivalent to the following configuration.
+
+```java
+ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());
+objectMapper.configOverride(BigInteger.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
+objectMapper.configOverride(BigDecimal.class).setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING));
+```
+
+### Serialize and deserialize Instant instances as MessagePack extension type
+
+`timestamp` extension type is defined in MessagePack as type:-1. Registering `TimestampExtensionModule.INSTANCE` module enables automatic serialization and deserialization of `java.time.Instant` to/from the MessagePack extension type.
+
+```java
+ObjectMapper objectMapper = MessagePackMapper.builder()
+        .addModule(TimestampExtensionModule.INSTANCE)
+        .build();
+Pojo pojo = new Pojo();
+// The type of `timestamp` variable is Instant
+pojo.timestamp = Instant.now();
+byte[] bytes = objectMapper.writeValueAsBytes(pojo);
+
+// The Instant instance is serialized as MessagePack extension type (type: -1)
+
+Pojo deserialized = objectMapper.readValue(bytes, Pojo.class);
+System.out.println(deserialized);   // "2022-09-14T08:47:24.922Z"
+```
+
+### Deserialize extension types with ExtensionTypeCustomDeserializers
+
+`ExtensionTypeCustomDeserializers` helps you to deserialize your own custom extension types easily.
+
+#### Deserialize extension type value directly
+
+```java
+// In this application, extension type 59 is used for byte[]
+byte[] bytes;
+{
+    // This ObjectMapper is just for temporary serialization
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    MessagePacker packer = MessagePack.newDefaultPacker(outputStream);
+
+    packer.packExtensionTypeHeader((byte) 59, hexspeak.length);
+    packer.addPayload(hexspeak);
+    packer.close();
+
+    bytes = outputStream.toByteArray();
+}
+
+// Register the type and a deserializer to ExtensionTypeCustomDeserializers
+ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+extTypeCustomDesers.addCustomDeser((byte) 59, data -> {
+    if (Arrays.equals(data,
+              new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE})) {
+        return "Java";
+    }
+    return "Not Java";
+});
+
+ObjectMapper objectMapper = new ObjectMapper(
+        new MessagePackFactory().setExtTypeCustomDesers(extTypeCustomDesers));
+
+System.out.println(objectMapper.readValue(bytes, Object.class));
+  // => Java
+```
+
+#### Use extension type as Map key
+
+```java
+static class TripleBytesPojo
+{
+  public byte first;
+  public byte second;
+  public byte third;
+
+  public TripleBytesPojo(byte first, byte second, byte third)
+  {
+    this.first = first;
+    this.second = second;
+    this.third = third;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    :
+  }
+
+  @Override
+  public int hashCode()
+  {
+    :
+  }
+
+  @Override
+  public String toString()
+  {
+    // This key format is used when serialized as map key
+    return String.format("%d-%d-%d", first, second, third);
+  }
+
+  static class KeyDeserializer
+      extends tools.jackson.databind.KeyDeserializer
+  {
+    @Override
+    public Object deserializeKey(String key, DeserializationContext ctxt)
+    {
+      String[] values = key.split("-");
+      return new TripleBytesPojo(Byte.parseByte(values[0]), Byte.parseByte(values[1]), Byte.parseByte(values[2]));
+    }
+  }
+
+  static TripleBytesPojo deserialize(byte[] bytes)
+  {
+    return new TripleBytesPojo(bytes[0], bytes[1], bytes[2]);
+  }
+}
+
+:
+
+byte extTypeCode = 42;
+
+ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+extTypeCustomDesers.addCustomDeser(extTypeCode, new ExtensionTypeCustomDeserializers.Deser()
+{
+  @Override
+  public Object deserialize(byte[] value)
+        throws IOException
+  {
+    return TripleBytesPojo.deserialize(value);
+  }
+});
+
+SimpleModule module = new SimpleModule();
+module.addKeyDeserializer(TripleBytesPojo.class, new TripleBytesPojo.KeyDeserializer());
+ObjectMapper objectMapper = MessagePackMapper.builder(
+        new MessagePackFactory().setExtTypeCustomDesers(extTypeCustomDesers))
+        .addModule(module)
+        .build();
+
+Map<TripleBytesPojo, Integer> deserializedMap =
+        objectMapper.readValue(serializedData,
+            new TypeReference<Map<TripleBytesPojo, Integer>>() {});
+```
+
+#### Use extension type as Map value
+
+```java
+static class TripleBytesPojo
+{
+  public byte first;
+  public byte second;
+  public byte third;
+
+  public TripleBytesPojo(byte first, byte second, byte third)
+  {
+    this.first = first;
+    this.second = second;
+    this.third = third;
+  }
+
+  static class Deserializer
+      extends StdDeserializer<TripleBytesPojo>
+  {
+    protected Deserializer()
+    {
+      super(TripleBytesPojo.class);
+    }
+
+    @Override
+    public TripleBytesPojo deserialize(JsonParser p, DeserializationContext ctxt)
+    {
+      return TripleBytesPojo.deserialize(p.getBinaryValue());
+    }
+  }
+
+  static TripleBytesPojo deserialize(byte[] bytes)
+  {
+    return new TripleBytesPojo(bytes[0], bytes[1], bytes[2]);
+  }
+}
+
+:
+
+byte extTypeCode = 42;
+
+ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+extTypeCustomDesers.addCustomDeser(extTypeCode, new ExtensionTypeCustomDeserializers.Deser()
+{
+  @Override
+  public Object deserialize(byte[] value)
+      throws IOException
+  {
+    return TripleBytesPojo.deserialize(value);
+  }
+});
+
+SimpleModule module = new SimpleModule();
+module.addDeserializer(TripleBytesPojo.class, new TripleBytesPojo.Deserializer());
+ObjectMapper objectMapper = MessagePackMapper.builder(
+        new MessagePackFactory().setExtTypeCustomDesers(extTypeCustomDesers))
+        .addModule(module)
+        .build();
+
+Map<String, TripleBytesPojo> deserializedMap =
+        objectMapper.readValue(serializedData,
+            new TypeReference<Map<String, TripleBytesPojo>>() {});
+```
+
+### Serialize a nested object that also serializes
+
+When you serialize an object that has a nested object also serializing with ObjectMapper and MessagePackFactory like the following code, it throws NullPointerException since the nested MessagePackFactory modifies a shared state stored in ThreadLocal.
+
+```java
+@Test
+public void testNestedSerialization() throws Exception
+{
+    ObjectMapper objectMapper = new MessagePackMapper();
+    objectMapper.writeValueAsBytes(new OuterClass());
+}
+
+public class OuterClass
+{
+  public String getInner() throws JacksonException
+  {
+    ObjectMapper m = new MessagePackMapper();
+    m.writeValueAsBytes(new InnerClass());
+    return "EFG";
+  }
+}
+
+public class InnerClass
+{
+  public String getName()
+  {
+    return "ABC";
+  }
+}
+```
+
+There are a few options to fix this issue, but they introduce performance degradations while this usage is a corner case. A workaround that doesn't affect performance is to call `MessagePackFactory#setReuseResourceInGenerator(false)`. It might be inconvenient to call the API for users, but it's a reasonable tradeoff with performance for now.
+
+```java
+ObjectMapper objectMapper = new ObjectMapper(
+  new MessagePackFactory().setReuseResourceInGenerator(false));
+```

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/BenchmarkState.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/BenchmarkState.java
@@ -1,0 +1,47 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark;
+
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.msgpack.jackson.dataformat.MessagePackMapper;
+import org.msgpack.jackson.dataformat.benchmark.model.MediaItem;
+import org.msgpack.jackson.dataformat.benchmark.model.MediaItems;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+@State(Scope.Thread)
+public class BenchmarkState
+{
+    public final ObjectMapper msgpackMapper = MessagePackMapper.builder(new MessagePackFactory()).build();
+    public final ObjectMapper jsonMapper = JsonMapper.builder().build();
+
+    public final byte[] msgpackBytes;
+    public final byte[] jsonBytes;
+
+    public BenchmarkState()
+    {
+        try {
+            MediaItem item = MediaItems.stdMediaItem();
+            msgpackBytes = msgpackMapper.writeValueAsBytes(item);
+            jsonBytes = jsonMapper.writeValueAsBytes(item);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/MsgpackReadBenchmark.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/MsgpackReadBenchmark.java
@@ -1,0 +1,52 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark;
+
+import org.msgpack.jackson.dataformat.benchmark.model.MediaItem;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class MsgpackReadBenchmark
+{
+    private final BenchmarkState state = new BenchmarkState();
+
+    @Benchmark
+    public Object readPojoMsgpack() throws Exception
+    {
+        return state.msgpackMapper.readValue(state.msgpackBytes, MediaItem.class);
+    }
+
+    @Benchmark
+    public Object readPojoJson() throws Exception
+    {
+        return state.jsonMapper.readValue(state.jsonBytes, MediaItem.class);
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/MsgpackWriteBenchmark.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/MsgpackWriteBenchmark.java
@@ -1,0 +1,58 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark;
+
+import org.msgpack.jackson.dataformat.benchmark.model.MediaItem;
+import org.msgpack.jackson.dataformat.benchmark.model.MediaItems;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class MsgpackWriteBenchmark
+{
+    private final BenchmarkState state = new BenchmarkState();
+    private final MediaItem item = MediaItems.stdMediaItem();
+
+    @Benchmark
+    public int writePojoMsgpack() throws Exception
+    {
+        NopOutputStream out = new NopOutputStream();
+        state.msgpackMapper.writeValue(out, item);
+        return out.size();
+    }
+
+    @Benchmark
+    public int writePojoJson() throws Exception
+    {
+        NopOutputStream out = new NopOutputStream();
+        state.jsonMapper.writeValue(out, item);
+        return out.size();
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/NopOutputStream.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/NopOutputStream.java
@@ -1,0 +1,41 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark;
+
+import java.io.OutputStream;
+
+public class NopOutputStream
+        extends OutputStream
+{
+    private int size;
+
+    @Override
+    public void write(int b)
+    {
+        size++;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len)
+    {
+        size += len;
+    }
+
+    public int size()
+    {
+        return size;
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/WriteUTF8StringBenchmark.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/WriteUTF8StringBenchmark.java
@@ -1,0 +1,86 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark;
+
+import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Compares writeUTF8String throughput for RawUtf8String (current) vs new String(bytes, UTF_8).
+ * Run this benchmark twice: once with the current implementation, once after replacing
+ * writeByteArrayTextValue to use new String(text, offset, len, StandardCharsets.UTF_8).
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+@Fork(2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class WriteUTF8StringBenchmark
+{
+    private static final int WRITES_PER_INVOCATION = 500;
+
+    private final MessagePackFactory factory = new MessagePackFactory();
+
+    // ASCII-only: compact-string fast path applies for new String(bytes, UTF_8)
+    private final byte[] asciiBytes =
+            "Hello, World! This is a typical ASCII field value.".getBytes(StandardCharsets.UTF_8);
+
+    // Non-ASCII: multi-byte UTF-8, compact-string fast path does NOT apply
+    private final byte[] nonAsciiBytes =
+            "東京は日本の首都です。This mixes CJK and ASCII.".getBytes(StandardCharsets.UTF_8);
+
+    @Benchmark
+    public int writeUTF8StringAscii() throws Exception
+    {
+        NopOutputStream out = new NopOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), out)) {
+            gen.writeStartArray();
+            for (int i = 0; i < WRITES_PER_INVOCATION; i++) {
+                gen.writeUTF8String(asciiBytes, 0, asciiBytes.length);
+            }
+            gen.writeEndArray();
+        }
+        return out.size();
+    }
+
+    @Benchmark
+    public int writeUTF8StringNonAscii() throws Exception
+    {
+        NopOutputStream out = new NopOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), out)) {
+            gen.writeStartArray();
+            for (int i = 0; i < WRITES_PER_INVOCATION; i++) {
+                gen.writeUTF8String(nonAsciiBytes, 0, nonAsciiBytes.length);
+            }
+            gen.writeEndArray();
+        }
+        return out.size();
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/Image.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/Image.java
@@ -1,0 +1,36 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark.model;
+
+public class Image
+{
+    public String uri;
+    public String title;
+    public int width;
+    public int height;
+    public Size size;
+
+    public Image() {}
+
+    public Image(String uri, String title, int width, int height, Size size)
+    {
+        this.uri = uri;
+        this.title = title;
+        this.width = width;
+        this.height = height;
+        this.size = size;
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/MediaContent.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/MediaContent.java
@@ -1,0 +1,44 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MediaContent
+{
+    public String uri;
+    public String title;
+    public int width;
+    public int height;
+    public String format;
+    public long duration;
+    public long size;
+    public int bitrate;
+    public List<String> persons;
+    public Player player;
+    public String copyright;
+
+    public MediaContent() {}
+
+    public void addPerson(String person)
+    {
+        if (persons == null) {
+            persons = new ArrayList<>();
+        }
+        persons.add(person);
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/MediaItem.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/MediaItem.java
@@ -1,0 +1,43 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark.model;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonPropertyOrder({"content", "images"})
+public class MediaItem
+{
+    public MediaContent content;
+    public List<Image> images;
+
+    public MediaItem() {}
+
+    public MediaItem(MediaContent content)
+    {
+        this.content = content;
+    }
+
+    public void addImage(Image image)
+    {
+        if (images == null) {
+            images = new ArrayList<>();
+        }
+        images.add(image);
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/MediaItems.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/MediaItems.java
@@ -1,0 +1,48 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark.model;
+
+public class MediaItems
+{
+    private static final MediaItem STD_MEDIA_ITEM;
+
+    static {
+        MediaContent content = new MediaContent();
+        content.uri = "http://javaone.com/keynote.mpg";
+        content.title = "Javaone Keynote";
+        content.width = 640;
+        content.height = 480;
+        content.format = "video/mpg4";
+        content.duration = 18000000L;
+        content.size = 58982400L;
+        content.bitrate = 262144;
+        content.player = Player.JAVA;
+        content.copyright = "None";
+        content.addPerson("Bill Gates");
+        content.addPerson("Steve Jobs");
+
+        MediaItem item = new MediaItem(content);
+        item.addImage(new Image("http://javaone.com/keynote_large.jpg", "Javaone Keynote", 1024, 768, Size.LARGE));
+        item.addImage(new Image("http://javaone.com/keynote_small.jpg", "Javaone Keynote", 320, 240, Size.SMALL));
+
+        STD_MEDIA_ITEM = item;
+    }
+
+    public static MediaItem stdMediaItem()
+    {
+        return STD_MEDIA_ITEM;
+    }
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/Player.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/Player.java
@@ -1,0 +1,21 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark.model;
+
+public enum Player
+{
+    JAVA, FLASH
+}

--- a/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/Size.java
+++ b/msgpack-jackson3/src/jmh/java/org/msgpack/jackson/dataformat/benchmark/model/Size.java
@@ -1,0 +1,21 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat.benchmark.model;
+
+public enum Size
+{
+    SMALL, LARGE
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/ExtensionTypeCustomDeserializers.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/ExtensionTypeCustomDeserializers.java
@@ -1,0 +1,56 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ExtensionTypeCustomDeserializers
+{
+    private Map<Byte, Deser> deserTable = new ConcurrentHashMap<>();
+
+    public ExtensionTypeCustomDeserializers()
+    {
+    }
+
+    public ExtensionTypeCustomDeserializers(ExtensionTypeCustomDeserializers src)
+    {
+        this();
+        this.deserTable.putAll(src.deserTable);
+    }
+
+    public void addCustomDeser(byte type, final Deser deser)
+    {
+        deserTable.put(type, deser);
+    }
+
+    public Deser getDeser(byte type)
+    {
+        return deserTable.get(type);
+    }
+
+    public void clearEntries()
+    {
+        deserTable.clear();
+    }
+
+    public interface Deser
+    {
+        Object deserialize(byte[] data)
+                throws IOException;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/JsonArrayFormat.java
@@ -1,0 +1,47 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.ARRAY;
+
+/**
+ * Provides the ability of serializing POJOs without their schema.
+ * Similar to @JsonFormat annotation with JsonFormat.Shape.ARRAY, but in a programmatic
+ * way.
+ *
+ * This also provides same behavior as msgpack-java 0.6.x serialization api.
+ */
+public class JsonArrayFormat extends JacksonAnnotationIntrospector
+{
+    private static final JsonFormat.Value ARRAY_FORMAT = new JsonFormat.Value().withShape(ARRAY);
+
+    @Override
+    public JsonFormat.Value findFormat(MapperConfig<?> config, Annotated ann)
+    {
+        JsonFormat.Value precedenceFormat = super.findFormat(config, ann);
+        if (precedenceFormat != null) {
+            return precedenceFormat;
+        }
+
+        return ARRAY_FORMAT;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackExtensionType.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackExtensionType.java
@@ -1,0 +1,99 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@JsonSerialize(using = MessagePackExtensionType.Serializer.class)
+public class MessagePackExtensionType
+{
+    private final byte type;
+    private final byte[] data;
+
+    public MessagePackExtensionType(byte type, byte[] data)
+    {
+        this.type = type;
+        this.data = Objects.requireNonNull(data, "data");
+    }
+
+    public byte getType()
+    {
+        return type;
+    }
+
+    public byte[] getData()
+    {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MessagePackExtensionType)) {
+            return false;
+        }
+
+        MessagePackExtensionType that = (MessagePackExtensionType) o;
+
+        if (type != that.type) {
+            return false;
+        }
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = type;
+        result = 31 * result + Arrays.hashCode(data);
+        return result;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "MessagePackExtensionType(type=" + type + ", data.length=" + data.length + ")";
+    }
+
+    public static class Serializer extends StdSerializer<MessagePackExtensionType>
+    {
+        public Serializer()
+        {
+            super(MessagePackExtensionType.class);
+        }
+
+        @Override
+        public void serialize(MessagePackExtensionType value, JsonGenerator gen, SerializationContext serializers)
+        {
+            if (gen instanceof MessagePackGenerator) {
+                MessagePackGenerator msgpackGenerator = (MessagePackGenerator) gen;
+                msgpackGenerator.writeExtensionType(value);
+            }
+            else {
+                throw new IllegalStateException("'gen' is expected to be MessagePackGenerator but it's " + gen.getClass());
+            }
+        }
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactory.java
@@ -1,0 +1,255 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.ErrorReportConfiguration;
+import tools.jackson.core.FormatFeature;
+import tools.jackson.core.FormatSchema;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.StreamWriteConstraints;
+import tools.jackson.core.TSFBuilder;
+import tools.jackson.core.TokenStreamFactory;
+import tools.jackson.core.Version;
+import tools.jackson.core.base.BinaryTSFactory;
+import tools.jackson.core.io.IOContext;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.annotations.VisibleForTesting;
+
+import org.msgpack.core.buffer.ArrayBufferInput;
+import org.msgpack.core.buffer.InputStreamBufferInput;
+import org.msgpack.core.buffer.MessageBufferInput;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class MessagePackFactory
+        extends BinaryTSFactory
+        implements java.io.Serializable
+{
+    private static final long serialVersionUID = 2578263992015504348L;
+
+    private final MessagePack.PackerConfig packerConfig;
+    private boolean reuseResourceInGenerator = true;
+    private boolean reuseResourceInParser = true;
+    private boolean supportIntegerKeys = false;
+    private ExtensionTypeCustomDeserializers extTypeCustomDesers;
+
+    public MessagePackFactory()
+    {
+        this(MessagePack.DEFAULT_PACKER_CONFIG);
+    }
+
+    public MessagePackFactory(MessagePack.PackerConfig packerConfig)
+    {
+        super(StreamReadConstraints.defaults(), StreamWriteConstraints.defaults(),
+                ErrorReportConfiguration.defaults(), 0, 0);
+        this.packerConfig = packerConfig;
+    }
+
+    public MessagePackFactory(MessagePackFactory src)
+    {
+        super(src);
+        this.packerConfig = src.packerConfig.clone();
+        this.reuseResourceInGenerator = src.reuseResourceInGenerator;
+        this.reuseResourceInParser = src.reuseResourceInParser;
+        this.supportIntegerKeys = src.supportIntegerKeys;
+        if (src.extTypeCustomDesers != null) {
+            this.extTypeCustomDesers = new ExtensionTypeCustomDeserializers(src.extTypeCustomDesers);
+        }
+    }
+
+    protected MessagePackFactory(MessagePackFactoryBuilder b)
+    {
+        super(b);
+        this.packerConfig = b.packerConfig().clone();
+        this.reuseResourceInGenerator = b.reuseResourceInGenerator();
+        this.reuseResourceInParser = b.reuseResourceInParser();
+        this.supportIntegerKeys = b.supportIntegerKeys();
+        this.extTypeCustomDesers = b.extTypeCustomDesers();
+    }
+
+    public MessagePackFactory setReuseResourceInGenerator(boolean reuseResourceInGenerator)
+    {
+        this.reuseResourceInGenerator = reuseResourceInGenerator;
+        return this;
+    }
+
+    public MessagePackFactory setReuseResourceInParser(boolean reuseResourceInParser)
+    {
+        this.reuseResourceInParser = reuseResourceInParser;
+        return this;
+    }
+
+    public MessagePackFactory setSupportIntegerKeys(boolean supportIntegerKeys)
+    {
+        this.supportIntegerKeys = supportIntegerKeys;
+        return this;
+    }
+
+    public MessagePackFactory setExtTypeCustomDesers(ExtensionTypeCustomDeserializers extTypeCustomDesers)
+    {
+        this.extTypeCustomDesers = extTypeCustomDesers;
+        return this;
+    }
+
+    @Override
+    protected JsonParser _createParser(ObjectReadContext readCtxt, IOContext ioCtxt,
+            InputStream in) throws JacksonException
+    {
+        try {
+            MessagePackParser parser = new MessagePackParser(readCtxt, ioCtxt,
+                    readCtxt.getStreamReadFeatures(_streamReadFeatures),
+                    new InputStreamBufferInput(in), in, reuseResourceInParser);
+            if (extTypeCustomDesers != null) {
+                parser.setExtensionTypeCustomDeserializers(extTypeCustomDesers);
+            }
+            return parser;
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+    }
+
+    @Override
+    protected JsonParser _createParser(ObjectReadContext readCtxt, IOContext ioCtxt,
+            byte[] data, int offset, int len) throws JacksonException
+    {
+        try {
+            MessageBufferInput input = new ArrayBufferInput(data, offset, len);
+            MessagePackParser parser = new MessagePackParser(readCtxt, ioCtxt,
+                    readCtxt.getStreamReadFeatures(_streamReadFeatures), input, data, reuseResourceInParser);
+            if (extTypeCustomDesers != null) {
+                parser.setExtensionTypeCustomDeserializers(extTypeCustomDesers);
+            }
+            return parser;
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+    }
+
+    @Override
+    protected JsonParser _createParser(ObjectReadContext readCtxt, IOContext ioCtxt,
+            DataInput input) throws JacksonException
+    {
+        return _unsupported();
+    }
+
+    @Override
+    protected JsonGenerator _createGenerator(ObjectWriteContext writeCtxt, IOContext ioCtxt,
+            OutputStream out) throws JacksonException
+    {
+        try {
+            return new MessagePackGenerator(writeCtxt, ioCtxt,
+                    writeCtxt.getStreamWriteFeatures(_streamWriteFeatures),
+                    out, packerConfig, reuseResourceInGenerator, supportIntegerKeys);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+    }
+
+    @Override
+    public TokenStreamFactory copy()
+    {
+        return new MessagePackFactory(this);
+    }
+
+    @Override
+    public TokenStreamFactory snapshot()
+    {
+        return copy();
+    }
+
+    @Override
+    public TSFBuilder<?, ?> rebuild()
+    {
+        return new MessagePackFactoryBuilder(this);
+    }
+
+    @Override
+    public Version version()
+    {
+        return PackageVersion.VERSION;
+    }
+
+    @VisibleForTesting
+    MessagePack.PackerConfig getPackerConfig()
+    {
+        return packerConfig;
+    }
+
+    @VisibleForTesting
+    boolean isReuseResourceInGenerator()
+    {
+        return reuseResourceInGenerator;
+    }
+
+    @VisibleForTesting
+    boolean isReuseResourceInParser()
+    {
+        return reuseResourceInParser;
+    }
+
+    @VisibleForTesting
+    boolean isSupportIntegerKeys()
+    {
+        return supportIntegerKeys;
+    }
+
+    @VisibleForTesting
+    ExtensionTypeCustomDeserializers getExtTypeCustomDesers()
+    {
+        return extTypeCustomDesers;
+    }
+
+    @Override
+    public String getFormatName()
+    {
+        return "msgpack";
+    }
+
+    @Override
+    public boolean canParseAsync()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean canUseSchema(FormatSchema schema)
+    {
+        return false;
+    }
+
+    @Override
+    public Class<? extends FormatFeature> getFormatReadFeatureType()
+    {
+        return null;
+    }
+
+    @Override
+    public Class<? extends FormatFeature> getFormatWriteFeatureType()
+    {
+        return null;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactoryBuilder.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackFactoryBuilder.java
@@ -1,0 +1,114 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.ErrorReportConfiguration;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.StreamWriteConstraints;
+import tools.jackson.core.base.DecorableTSFactory;
+import org.msgpack.core.MessagePack;
+
+public class MessagePackFactoryBuilder
+        extends DecorableTSFactory.DecorableTSFBuilder<MessagePackFactory, MessagePackFactoryBuilder>
+{
+    private MessagePack.PackerConfig packerConfig;
+    private boolean reuseResourceInGenerator;
+    private boolean reuseResourceInParser;
+    private boolean supportIntegerKeys;
+    private ExtensionTypeCustomDeserializers extTypeCustomDesers;
+
+    public MessagePackFactoryBuilder()
+    {
+        super(StreamReadConstraints.defaults(), StreamWriteConstraints.defaults(),
+                ErrorReportConfiguration.defaults(), 0, 0);
+        this.packerConfig = MessagePack.DEFAULT_PACKER_CONFIG;
+        this.reuseResourceInGenerator = true;
+        this.reuseResourceInParser = true;
+        this.supportIntegerKeys = false;
+    }
+
+    public MessagePackFactoryBuilder(MessagePackFactory base)
+    {
+        super(base);
+        this.packerConfig = base.getPackerConfig().clone();
+        this.reuseResourceInGenerator = base.isReuseResourceInGenerator();
+        this.reuseResourceInParser = base.isReuseResourceInParser();
+        this.supportIntegerKeys = base.isSupportIntegerKeys();
+        ExtensionTypeCustomDeserializers srcDesers = base.getExtTypeCustomDesers();
+        this.extTypeCustomDesers = srcDesers == null ? null : new ExtensionTypeCustomDeserializers(srcDesers);
+    }
+
+    public MessagePackFactoryBuilder packerConfig(MessagePack.PackerConfig config)
+    {
+        this.packerConfig = config;
+        return this;
+    }
+
+    public MessagePackFactoryBuilder reuseResourceInGenerator(boolean v)
+    {
+        this.reuseResourceInGenerator = v;
+        return this;
+    }
+
+    public MessagePackFactoryBuilder reuseResourceInParser(boolean v)
+    {
+        this.reuseResourceInParser = v;
+        return this;
+    }
+
+    public MessagePackFactoryBuilder supportIntegerKeys(boolean v)
+    {
+        this.supportIntegerKeys = v;
+        return this;
+    }
+
+    public MessagePackFactoryBuilder extTypeCustomDesers(ExtensionTypeCustomDeserializers desers)
+    {
+        this.extTypeCustomDesers = desers;
+        return this;
+    }
+
+    public MessagePack.PackerConfig packerConfig()
+    {
+        return packerConfig;
+    }
+
+    public boolean reuseResourceInGenerator()
+    {
+        return reuseResourceInGenerator;
+    }
+
+    public boolean reuseResourceInParser()
+    {
+        return reuseResourceInParser;
+    }
+
+    public boolean supportIntegerKeys()
+    {
+        return supportIntegerKeys;
+    }
+
+    public ExtensionTypeCustomDeserializers extTypeCustomDesers()
+    {
+        return extTypeCustomDesers;
+    }
+
+    @Override
+    public MessagePackFactory build()
+    {
+        return new MessagePackFactory(this);
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackGenerator.java
@@ -1,0 +1,1041 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.Base64Variant;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.util.JacksonFeatureSet;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.SerializableString;
+import tools.jackson.core.StreamWriteCapability;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.json.DupDetector;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.base.GeneratorBase;
+import tools.jackson.core.io.IOContext;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.buffer.MessageBufferOutput;
+import org.msgpack.core.buffer.OutputStreamBufferOutput;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MessagePackGenerator
+        extends GeneratorBase
+{
+    private static final int IN_ROOT = 0;
+    private static final int IN_OBJECT = 1;
+    private static final int IN_ARRAY = 2;
+    private final MessagePacker messagePacker;
+    // Retained heap per idle thread: ~8 KB (OutputStreamBufferOutput + internal MessageBuffer).
+    // Negligible compared to Jackson's own per-thread buffer retention.
+    private static final ThreadLocal<OutputStreamBufferOutput> messageBufferOutputHolder = new ThreadLocal<>();
+    private final OutputStream output;
+    private final MessagePack.PackerConfig packerConfig;
+    private final boolean supportIntegerKeys;
+
+    private int currentParentElementIndex = -1;
+    private int currentState = IN_ROOT;
+    private final List<Node> nodes;
+    private boolean isElementsClosed = false;
+    private MessagePackWriteContext writeContext;
+    private final boolean ownsThreadLocalBuffer;
+
+    private static final class RawUtf8String
+    {
+        public final byte[] bytes;
+        public final int offset;
+        public final int len;
+
+        public RawUtf8String(byte[] bytes, int offset, int len)
+        {
+            this.bytes = bytes;
+            this.offset = offset;
+            this.len = len;
+        }
+    }
+
+    private abstract static class Node
+    {
+        // Root containers have -1.
+        final int parentIndex;
+
+        public Node(int parentIndex)
+        {
+            this.parentIndex = parentIndex;
+        }
+
+        abstract void incrementChildCount();
+
+        abstract int currentStateAsParent();
+    }
+
+    private abstract static class NodeContainer extends Node
+    {
+        // Only for containers.
+        int childCount;
+
+        public NodeContainer(int parentIndex)
+        {
+            super(parentIndex);
+        }
+
+        @Override
+        void incrementChildCount()
+        {
+            childCount++;
+        }
+    }
+
+    private static final class NodeArray extends NodeContainer
+    {
+        public NodeArray(int parentIndex)
+        {
+            super(parentIndex);
+        }
+
+        @Override
+        int currentStateAsParent()
+        {
+            return IN_ARRAY;
+        }
+    }
+
+    private static final class NodeObject extends NodeContainer
+    {
+        public NodeObject(int parentIndex)
+        {
+            super(parentIndex);
+        }
+
+        @Override
+        int currentStateAsParent()
+        {
+            return IN_OBJECT;
+        }
+    }
+
+    private static final class NodeEntryInArray extends Node
+    {
+        final Object value;
+
+        public NodeEntryInArray(int parentIndex, Object value)
+        {
+            super(parentIndex);
+            this.value = value;
+        }
+
+        @Override
+        void incrementChildCount()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        int currentStateAsParent()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class NodeEntryInObject extends Node
+    {
+        final Object key;
+        // Lazily initialized.
+        Object value;
+
+        public NodeEntryInObject(int parentIndex, Object key)
+        {
+            super(parentIndex);
+            this.key = key;
+        }
+
+        @Override
+        void incrementChildCount()
+        {
+            assert value instanceof NodeContainer;
+            ((NodeContainer) value).childCount++;
+        }
+
+        @Override
+        int currentStateAsParent()
+        {
+            if (value instanceof NodeObject) {
+                return IN_OBJECT;
+            }
+            else if (value instanceof NodeArray) {
+                return IN_ARRAY;
+            }
+            else {
+                throw new AssertionError();
+            }
+        }
+    }
+
+    // Internal constructor for nested serialization.
+    private MessagePackGenerator(
+            ObjectWriteContext writeCtxt,
+            IOContext ioCtxt,
+            int streamWriteFeatures,
+            OutputStream out,
+            MessagePack.PackerConfig packerConfig,
+            boolean supportIntegerKeys)
+    {
+        super(writeCtxt, ioCtxt, streamWriteFeatures);
+        this.output = out;
+        this.messagePacker = packerConfig.newPacker(out);
+        this.packerConfig = packerConfig;
+        this.nodes = new ArrayList<>();
+        this.supportIntegerKeys = supportIntegerKeys;
+        this.writeContext = MessagePackWriteContext.createRootContext(
+                StreamWriteFeature.STRICT_DUPLICATE_DETECTION.enabledIn(streamWriteFeatures)
+                        ? DupDetector.rootDetector(this) : null);
+        this.ownsThreadLocalBuffer = false;
+    }
+
+    public MessagePackGenerator(
+            ObjectWriteContext writeCtxt,
+            IOContext ioCtxt,
+            int streamWriteFeatures,
+            OutputStream out,
+            MessagePack.PackerConfig packerConfig,
+            boolean reuseResourceInGenerator,
+            boolean supportIntegerKeys)
+            throws IOException
+    {
+        super(writeCtxt, ioCtxt, streamWriteFeatures);
+        this.output = out;
+        this.messagePacker = packerConfig.newPacker(getMessageBufferOutputForOutputStream(out, reuseResourceInGenerator));
+        this.packerConfig = packerConfig;
+        this.nodes = new ArrayList<>();
+        this.supportIntegerKeys = supportIntegerKeys;
+        this.writeContext = MessagePackWriteContext.createRootContext(
+                StreamWriteFeature.STRICT_DUPLICATE_DETECTION.enabledIn(streamWriteFeatures)
+                        ? DupDetector.rootDetector(this) : null);
+        this.ownsThreadLocalBuffer = reuseResourceInGenerator;
+    }
+
+    private MessageBufferOutput getMessageBufferOutputForOutputStream(
+            OutputStream out,
+            boolean reuseResourceInGenerator)
+            throws IOException
+    {
+        OutputStreamBufferOutput messageBufferOutput;
+        if (reuseResourceInGenerator) {
+            messageBufferOutput = messageBufferOutputHolder.get();
+            if (messageBufferOutput == null) {
+                messageBufferOutput = new OutputStreamBufferOutput(out);
+                messageBufferOutputHolder.set(messageBufferOutput);
+            }
+            else {
+                messageBufferOutput.reset(out);
+            }
+        }
+        else {
+            messageBufferOutput = new OutputStreamBufferOutput(out);
+        }
+        return messageBufferOutput;
+    }
+
+    private String currentStateStr()
+    {
+        switch (currentState) {
+            case IN_OBJECT:
+                return "IN_OBJECT";
+            case IN_ARRAY:
+                return "IN_ARRAY";
+            default:
+                return "IN_ROOT";
+        }
+    }
+
+    @Override
+    public JsonGenerator writeStartArray() throws JacksonException
+    {
+        return writeStartArray(null);
+    }
+
+    @Override
+    public JsonGenerator writeStartArray(Object currentValue) throws JacksonException
+    {
+        return writeStartArray(currentValue, -1);
+    }
+
+    // size is ignored: element count is determined at flush time from the actual child nodes.
+    // When size >= 0, it could in principle be used to skip buffering and write the array
+    // header immediately, but Jackson does not guarantee it — dynamic filters (Views,
+    // @JsonFilter) evaluate entries incrementally and will pass -1 even for known-size
+    // collections. Backends must handle both cases (Jackson author confirmed, see #841).
+    @Override
+    public JsonGenerator writeStartArray(Object currentValue, int size) throws JacksonException
+    {
+        _verifyValueWrite("start an array");
+        writeContext = writeContext.createChildArrayContext(currentValue);
+        if (currentState == IN_OBJECT) {
+            Node node = nodes.get(nodes.size() - 1);
+            assert node instanceof NodeEntryInObject;
+            NodeEntryInObject nodeEntryInObject = (NodeEntryInObject) node;
+            nodeEntryInObject.value = new NodeArray(currentParentElementIndex);
+        }
+        else {
+            if (isElementsClosed) {
+                flush();
+            }
+            nodes.add(new NodeArray(currentParentElementIndex));
+        }
+        currentParentElementIndex = nodes.size() - 1;
+        currentState = IN_ARRAY;
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeEndArray() throws JacksonException
+    {
+        if (currentState != IN_ARRAY) {
+            _reportError("Current context not an array but " + currentStateStr());
+        }
+        endCurrentContainer();
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeStartObject() throws JacksonException
+    {
+        return writeStartObject(null);
+    }
+
+    @Override
+    public JsonGenerator writeStartObject(Object currentValue) throws JacksonException
+    {
+        return writeStartObject(currentValue, -1);
+    }
+
+    // size is ignored: same reasoning as writeStartArray(Object, int) above.
+    @Override
+    public JsonGenerator writeStartObject(Object forValue, int size) throws JacksonException
+    {
+        _verifyValueWrite("start an object");
+        writeContext = writeContext.createChildObjectContext(forValue);
+        if (currentState == IN_OBJECT) {
+            Node node = nodes.get(nodes.size() - 1);
+            assert node instanceof NodeEntryInObject;
+            NodeEntryInObject nodeEntryInObject = (NodeEntryInObject) node;
+            nodeEntryInObject.value = new NodeObject(currentParentElementIndex);
+        }
+        else {
+            if (isElementsClosed) {
+                flush();
+            }
+            nodes.add(new NodeObject(currentParentElementIndex));
+        }
+        currentParentElementIndex = nodes.size() - 1;
+        currentState = IN_OBJECT;
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeEndObject() throws JacksonException
+    {
+        if (currentState != IN_OBJECT) {
+            _reportError("Current context not an object but " + currentStateStr());
+        }
+        if (writeContext.isExpectingValue()) {
+            _reportError("Cannot close Object, property name written but no value");
+        }
+        endCurrentContainer();
+        return this;
+    }
+
+    private void endCurrentContainer()
+    {
+        writeContext = writeContext.getParent();
+        Node parent = nodes.get(currentParentElementIndex);
+        if (parent.parentIndex == -1) {
+            isElementsClosed = true;
+            currentParentElementIndex = parent.parentIndex;
+            currentState = IN_ROOT;
+            return;
+        }
+
+        currentParentElementIndex = parent.parentIndex;
+        Node currentParent = nodes.get(currentParentElementIndex);
+        currentParent.incrementChildCount();
+        currentState = currentParent.currentStateAsParent();
+    }
+
+    private void packNonContainer(Object v)
+            throws IOException
+    {
+        MessagePacker messagePacker = getMessagePacker();
+        if (v instanceof String) {
+            messagePacker.packString((String) v);
+        }
+        else if (v instanceof RawUtf8String) {
+            RawUtf8String raw = (RawUtf8String) v;
+            messagePacker.packRawStringHeader(raw.len);
+            messagePacker.writePayload(raw.bytes, raw.offset, raw.len);
+        }
+        else if (v instanceof Integer) {
+            messagePacker.packInt((Integer) v);
+        }
+        else if (v == null) {
+            messagePacker.packNil();
+        }
+        else if (v instanceof Float) {
+            messagePacker.packFloat((Float) v);
+        }
+        else if (v instanceof Long) {
+            messagePacker.packLong((Long) v);
+        }
+        else if (v instanceof Double) {
+            messagePacker.packDouble((Double) v);
+        }
+        else if (v instanceof BigInteger) {
+            messagePacker.packBigInteger((BigInteger) v);
+        }
+        else if (v instanceof BigDecimal) {
+            packBigDecimal((BigDecimal) v);
+        }
+        else if (v instanceof Boolean) {
+            messagePacker.packBoolean((Boolean) v);
+        }
+        else if (v instanceof ByteBuffer) {
+            ByteBuffer bb = (ByteBuffer) v;
+            int len = bb.remaining();
+            if (bb.hasArray() && !bb.isReadOnly()) {
+                messagePacker.packBinaryHeader(len);
+                messagePacker.writePayload(bb.array(), bb.arrayOffset() + bb.position(), len);
+            }
+            else {
+                byte[] data = new byte[len];
+                bb.duplicate().get(data);
+                messagePacker.packBinaryHeader(len);
+                messagePacker.addPayload(data);
+            }
+        }
+        else if (v instanceof MessagePackExtensionType) {
+            MessagePackExtensionType extensionType = (MessagePackExtensionType) v;
+            byte[] extData = extensionType.getData();
+            messagePacker.packExtensionTypeHeader(extensionType.getType(), extData.length);
+            messagePacker.writePayload(extData);
+        }
+        else {
+            messagePacker.flush();
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try (MessagePackGenerator messagePackGenerator = new MessagePackGenerator(
+                    objectWriteContext(), _ioContext, _streamWriteFeatures,
+                    outputStream, packerConfig, supportIntegerKeys)) {
+                objectWriteContext().writeValue(messagePackGenerator, v);
+            }
+            output.write(outputStream.toByteArray());
+        }
+    }
+
+    private void packBigDecimal(BigDecimal decimal)
+            throws IOException
+    {
+        MessagePacker messagePacker = getMessagePacker();
+        boolean failedToPackAsBI = false;
+        try {
+            //Check to see if this BigDecimal can be converted to BigInteger
+            BigInteger integer = decimal.toBigIntegerExact();
+            messagePacker.packBigInteger(integer);
+        }
+        catch (ArithmeticException | IllegalArgumentException e) {
+            failedToPackAsBI = true;
+        }
+
+        if (failedToPackAsBI) {
+            double doubleValue = decimal.doubleValue();
+            //Check to make sure this BigDecimal can be represented as a double
+            if (Double.isInfinite(doubleValue) || decimal.compareTo(BigDecimal.valueOf(doubleValue)) != 0) {
+                throw new IllegalArgumentException("MessagePack cannot serialize a BigDecimal that can't be represented as double. " + decimal);
+            }
+            messagePacker.packDouble(doubleValue);
+        }
+    }
+
+    private void packObject(NodeObject container)
+            throws IOException
+    {
+        MessagePacker messagePacker = getMessagePacker();
+        messagePacker.packMapHeader(container.childCount);
+    }
+
+    private void packArray(NodeArray container)
+            throws IOException
+    {
+        MessagePacker messagePacker = getMessagePacker();
+        messagePacker.packArrayHeader(container.childCount);
+    }
+
+    private void addKeyNode(Object key)
+    {
+        if (currentState != IN_OBJECT) {
+            _reportError("Can not write a property name, expecting a value");
+        }
+        nodes.add(new NodeEntryInObject(currentParentElementIndex, key));
+    }
+
+    private void addValueNode(Object value) throws IOException
+    {
+        if (!writeContext.writeValue()) {
+            _reportError("Cannot write value: expecting a property name in Object context");
+        }
+        switch (currentState) {
+            case IN_OBJECT: {
+                Node node = nodes.get(nodes.size() - 1);
+                assert node instanceof NodeEntryInObject;
+                NodeEntryInObject nodeEntryInObject = (NodeEntryInObject) node;
+                nodeEntryInObject.value = value;
+                nodes.get(node.parentIndex).incrementChildCount();
+                break;
+            }
+            case IN_ARRAY: {
+                Node node = new NodeEntryInArray(currentParentElementIndex, value);
+                nodes.add(node);
+                nodes.get(node.parentIndex).incrementChildCount();
+                break;
+            }
+            default:
+                // Flush any buffered root container before packing a root scalar,
+                // otherwise the scalar would be emitted before the container.
+                if (isElementsClosed) {
+                    flush();
+                }
+                packNonContainer(value);
+                flushMessagePacker();
+                break;
+        }
+    }
+
+    private void writeCharArrayTextValue(char[] text, int offset, int len) throws IOException
+    {
+        addValueNode(new String(text, offset, len));
+    }
+
+    private void writeByteArrayTextValue(byte[] text, int offset, int len) throws IOException
+    {
+        addValueNode(new RawUtf8String(text, offset, len));
+    }
+
+    @Override
+    public JsonGenerator writePropertyId(long id) throws JacksonException
+    {
+        if (this.supportIntegerKeys) {
+            if (!writeContext.writeName(String.valueOf(id))) {
+                _reportError("Can not write a property id, expecting a value");
+            }
+            addKeyNode(id);
+        }
+        else {
+            writeName(String.valueOf(id));
+        }
+        return this;
+    }
+
+    @Override
+    public JacksonFeatureSet<StreamWriteCapability> streamWriteCapabilities()
+    {
+        return DEFAULT_BINARY_WRITE_CAPABILITIES;
+    }
+
+    @Override
+    public JsonGenerator writeName(String name) throws JacksonException
+    {
+        if (!writeContext.writeName(name)) {
+            _reportError("Can not write a property name, expecting a value");
+        }
+        addKeyNode(name);
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeName(SerializableString name) throws JacksonException
+    {
+        if (name instanceof MessagePackSerializedString) {
+            if (!writeContext.writeName(name.getValue())) {
+                _reportError("Can not write a property name, expecting a value");
+            }
+            addKeyNode(((MessagePackSerializedString) name).getRawValue());
+        }
+        else {
+            writeName(name.getValue());
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeString(String text) throws JacksonException
+    {
+        try {
+            addValueNode(text);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeString(char[] text, int offset, int len) throws JacksonException
+    {
+        try {
+            writeCharArrayTextValue(text, offset, len);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeString(Reader reader, int len) throws JacksonException
+    {
+        try {
+            long remaining = len < 0 ? Long.MAX_VALUE : len;
+            // Cap chunk size: len is a caller hint and can be arbitrarily large.
+            // Pre-allocating new StringBuilder(len) would reserve len*2 bytes upfront,
+            // which is an OOM risk for large inputs. The StringBuilder grows as needed.
+            int chunkSize = (int) Math.min(remaining, 8192);
+            StringBuilder sb = new StringBuilder(chunkSize);
+            char[] tmpBuf = new char[chunkSize];
+            while (remaining > 0) {
+                int read = reader.read(tmpBuf, 0, (int) Math.min(remaining, tmpBuf.length));
+                if (read < 0) {
+                    break;
+                }
+                sb.append(tmpBuf, 0, read);
+                remaining -= read;
+            }
+            addValueNode(sb.toString());
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeString(SerializableString text) throws JacksonException
+    {
+        return writeString(text.getValue());
+    }
+
+    @Override
+    public JsonGenerator writeRawUTF8String(byte[] text, int offset, int length) throws JacksonException
+    {
+        try {
+            writeByteArrayTextValue(text, offset, length);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeUTF8String(byte[] text, int offset, int length) throws JacksonException
+    {
+        try {
+            writeByteArrayTextValue(text, offset, length);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeRaw(String text) throws JacksonException
+    {
+        try {
+            addValueNode(text);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeRaw(String text, int offset, int len) throws JacksonException
+    {
+        try {
+            addValueNode(text.substring(offset, offset + len));
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeRaw(char[] text, int offset, int len) throws JacksonException
+    {
+        try {
+            writeCharArrayTextValue(text, offset, len);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeRaw(char c) throws JacksonException
+    {
+        try {
+            writeCharArrayTextValue(new char[] { c }, 0, 1);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeBinary(Base64Variant b64variant, byte[] data, int offset, int len) throws JacksonException
+    {
+        try {
+            addValueNode(ByteBuffer.wrap(data, offset, len));
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(short v) throws JacksonException
+    {
+        return writeNumber((int) v);
+    }
+
+    @Override
+    public JsonGenerator writeNumber(int v) throws JacksonException
+    {
+        try {
+            addValueNode(v);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(long v) throws JacksonException
+    {
+        try {
+            addValueNode(v);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(BigInteger v) throws JacksonException
+    {
+        try {
+            addValueNode(v);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(double d) throws JacksonException
+    {
+        try {
+            addValueNode(d);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(float f) throws JacksonException
+    {
+        try {
+            addValueNode(f);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(BigDecimal dec) throws JacksonException
+    {
+        try {
+            addValueNode(dec);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNumber(String encodedValue) throws JacksonException
+    {
+        // There is a room to improve this API's performance while the implementation is robust.
+        // If users can use other MessagePackGenerator#writeNumber APIs that accept
+        // proper numeric types not String, it's better to use the other APIs instead.
+        try {
+            try {
+                long l = Long.parseLong(encodedValue);
+                addValueNode(l);
+                return this;
+            }
+            catch (NumberFormatException ignored) {
+            }
+
+            try {
+                BigInteger bi = new BigInteger(encodedValue);
+                addValueNode(bi);
+                return this;
+            }
+            catch (NumberFormatException ignored) {
+            }
+
+            try {
+                BigDecimal bd = new BigDecimal(encodedValue);
+                double d = bd.doubleValue();
+
+                // Check if the double can perfectly represent the exact decimal value.
+                // isInfinite guard: values like "1e309" overflow double to Infinity; keep as BigDecimal.
+                if (!Double.isInfinite(d) && bd.compareTo(new BigDecimal(String.valueOf(d))) == 0) {
+                    // It's a safe ordinary floating-point number.
+                    addValueNode(d);
+                }
+                else {
+                    // It has more precision than a double can handle, or overflows double range.
+                    addValueNode(bd);
+                }
+                return this;
+            }
+            catch (NumberFormatException e) {
+                // Fall back for NaN, Infinity, -Infinity which BigDecimal rejects.
+                try {
+                    double d = Double.parseDouble(encodedValue);
+                    addValueNode(d);
+                    return this;
+                }
+                catch (NumberFormatException ignored) {
+                }
+            }
+
+            throw new NumberFormatException(encodedValue);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+    }
+
+    @Override
+    public JsonGenerator writeBoolean(boolean state) throws JacksonException
+    {
+        try {
+            addValueNode(state);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    @Override
+    public JsonGenerator writeNull() throws JacksonException
+    {
+        try {
+            addValueNode(null);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        return this;
+    }
+
+    public void writeExtensionType(MessagePackExtensionType extensionType)
+    {
+        try {
+            addValueNode(extensionType);
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+    }
+
+    @Override
+    public void close() throws JacksonException
+    {
+        if (!_closed) {
+            try {
+                flush();
+            }
+            finally {
+                super.close();
+            }
+        }
+    }
+
+    @Override
+    public void flush() throws JacksonException
+    {
+        if (!isElementsClosed) {
+            // The whole elements are not closed yet.
+            return;
+        }
+
+        try {
+            for (int i = 0; i < nodes.size(); i++) {
+                Node node = nodes.get(i);
+                if (node instanceof NodeEntryInObject) {
+                    NodeEntryInObject nodeEntry = (NodeEntryInObject) node;
+                    packNonContainer(nodeEntry.key);
+                    if (nodeEntry.value instanceof NodeObject) {
+                        packObject((NodeObject) nodeEntry.value);
+                    }
+                    else if (nodeEntry.value instanceof NodeArray) {
+                        packArray((NodeArray) nodeEntry.value);
+                    }
+                    else {
+                        packNonContainer(nodeEntry.value);
+                    }
+                }
+                else if (node instanceof NodeObject) {
+                    packObject((NodeObject) node);
+                }
+                else if (node instanceof NodeEntryInArray) {
+                    packNonContainer(((NodeEntryInArray) node).value);
+                }
+                else if (node instanceof NodeArray) {
+                    packArray((NodeArray) node);
+                }
+                else {
+                    throw new AssertionError();
+                }
+            }
+            flushMessagePacker();
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        nodes.clear();
+        isElementsClosed = false;
+    }
+
+    private void flushMessagePacker()
+            throws IOException
+    {
+        getMessagePacker().flush();
+    }
+
+    @Override
+    public tools.jackson.core.Version version()
+    {
+        return PackageVersion.VERSION;
+    }
+
+    @Override
+    public TokenStreamContext streamWriteContext()
+    {
+        return writeContext;
+    }
+
+    @Override
+    public Object streamWriteOutputTarget()
+    {
+        return output;
+    }
+
+    @Override
+    public int streamWriteOutputBuffered()
+    {
+        return -1;
+    }
+
+    @Override
+    public Object currentValue()
+    {
+        return writeContext.currentValue();
+    }
+
+    @Override
+    public void assignCurrentValue(Object v)
+    {
+        writeContext.assignCurrentValue(v);
+    }
+
+    @Override
+    protected void _closeInput() throws IOException
+    {
+        if (StreamWriteFeature.AUTO_CLOSE_TARGET.enabledIn(_streamWriteFeatures)) {
+            messagePacker.close();
+        }
+    }
+
+    @Override
+    protected void _releaseBuffers()
+    {
+        // No null check on get(): generators are single-threaded by contract so this
+        // ThreadLocal is always set on the calling thread. A null here would indicate
+        // cross-thread misuse; letting it NPE surfaces that bug immediately.
+        if (ownsThreadLocalBuffer) {
+            OutputStreamBufferOutput buf = messageBufferOutputHolder.get();
+            if (buf != null) {
+                try {
+                    buf.reset(null);
+                }
+                catch (IOException e) {
+                    throw _wrapIOFailure(e);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void _verifyValueWrite(String typeMsg) throws JacksonException
+    {
+        if (!writeContext.writeValue()) {
+            _reportError("Cannot " + typeMsg + ", expecting a property name");
+        }
+    }
+
+    private MessagePacker getMessagePacker()
+    {
+        return messagePacker;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackKeySerializer.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackKeySerializer.java
@@ -1,0 +1,35 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+public class MessagePackKeySerializer
+        extends StdSerializer<Object>
+{
+    public MessagePackKeySerializer()
+    {
+        super(Object.class);
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator jgen, SerializationContext provider)
+    {
+        jgen.writeName(new MessagePackSerializedString(value));
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackMapper.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackMapper.java
@@ -1,0 +1,120 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import tools.jackson.core.Version;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.cfg.MapperBuilderState;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class MessagePackMapper extends ObjectMapper
+{
+    private static final long serialVersionUID = 3L;
+
+    public static class Builder extends MapperBuilder<MessagePackMapper, Builder>
+    {
+        public Builder(MessagePackFactory f)
+        {
+            super(f);
+        }
+
+        protected Builder(StateImpl state)
+        {
+            super(state);
+        }
+
+        @Override
+        public MessagePackMapper build()
+        {
+            return new MessagePackMapper(this);
+        }
+
+        public Builder handleBigIntegerAsString()
+        {
+            return withConfigOverride(BigInteger.class,
+                    o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)));
+        }
+
+        public Builder handleBigDecimalAsString()
+        {
+            return withConfigOverride(BigDecimal.class,
+                    o -> o.setFormat(JsonFormat.Value.forShape(JsonFormat.Shape.STRING)));
+        }
+
+        public Builder handleBigIntegerAndBigDecimalAsString()
+        {
+            return handleBigIntegerAsString().handleBigDecimalAsString();
+        }
+
+        @Override
+        protected MapperBuilderState _saveState()
+        {
+            return new StateImpl(this);
+        }
+
+        protected static class StateImpl extends MapperBuilderState
+        {
+            private static final long serialVersionUID = 3L;
+
+            public StateImpl(Builder src)
+            {
+                super(src);
+            }
+
+            @Override
+            protected Object readResolve()
+            {
+                return new Builder(this).build();
+            }
+        }
+    }
+
+    public MessagePackMapper()
+    {
+        this(new Builder(new MessagePackFactory()));
+    }
+
+    public MessagePackMapper(MessagePackFactory f)
+    {
+        this(new Builder(f));
+    }
+
+    protected MessagePackMapper(Builder builder)
+    {
+        super(builder);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder(new MessagePackFactory());
+    }
+
+    public static Builder builder(MessagePackFactory f)
+    {
+        return new Builder(f);
+    }
+
+    @Override
+    public Version version()
+    {
+        return PackageVersion.VERSION;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackParser.java
@@ -1,0 +1,801 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.Base64Variant;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.Version;
+import tools.jackson.core.base.ParserMinimalBase;
+import tools.jackson.core.exc.UnexpectedEndOfInputException;
+import tools.jackson.core.io.IOContext;
+import tools.jackson.core.json.DupDetector;
+import org.msgpack.core.ExtensionTypeHeader;
+import org.msgpack.core.MessageFormat;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessageUnpacker;
+import org.msgpack.core.buffer.MessageBufferInput;
+import org.msgpack.value.ValueType;
+
+import java.io.IOException;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class MessagePackParser
+        extends ParserMinimalBase
+{
+    // Retained heap per idle thread: ~0.2 KB (MessageUnpacker with cleared input buffer).
+    // Negligible compared to Jackson's own per-thread buffer retention.
+    private static final ThreadLocal<Tuple<Object, MessageUnpacker>> messageUnpackerHolder = new ThreadLocal<>();
+    private final MessageUnpacker messageUnpacker;
+
+    private static final BigInteger LONG_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+
+    private MessagePackReadContext streamReadContext;
+
+    private boolean isClosed;
+    private long tokenPosition;
+    private long currentPosition;
+    private final IOContext ioContext;
+    private ExtensionTypeCustomDeserializers extTypeCustomDesers;
+    private final boolean ownsThreadLocalUnpacker;
+
+    private enum Type
+    {
+        INT, LONG, DOUBLE, STRING, BYTES, BOOL, BIG_INT, EXT, NULL
+    }
+    private Type type;
+    private int intValue;
+    private long longValue;
+    private double doubleValue;
+    private boolean booleanValue;
+    private byte[] bytesValue;
+    private String stringValue;
+    private BigInteger biValue;
+    private MessagePackExtensionType extensionTypeValue;
+
+    MessagePackParser(ObjectReadContext readCtxt,
+            IOContext ioCtxt,
+            int streamReadFeatures,
+            MessageBufferInput input,
+            Object src,
+            boolean reuseResourceInParser)
+            throws IOException
+    {
+        super(readCtxt, ioCtxt, streamReadFeatures);
+
+        ioContext = ioCtxt;
+        DupDetector dups = StreamReadFeature.STRICT_DUPLICATE_DETECTION.enabledIn(streamReadFeatures)
+                ? DupDetector.rootDetector(this) : null;
+        streamReadContext = MessagePackReadContext.createRootContext(dups);
+        if (!reuseResourceInParser) {
+            messageUnpacker = MessagePack.newDefaultUnpacker(input);
+            ownsThreadLocalUnpacker = false;
+            return;
+        }
+
+        Tuple<Object, MessageUnpacker> messageUnpackerTuple = messageUnpackerHolder.get();
+        if (messageUnpackerTuple == null) {
+            messageUnpacker = MessagePack.newDefaultUnpacker(input);
+        }
+        else {
+            // Considering to reuse InputStream with StreamReadFeature.AUTO_CLOSE_SOURCE,
+            // MessagePackParser needs to use the MessageUnpacker that has the same InputStream
+            // since it has buffer which has loaded the InputStream data ahead.
+            // However, it needs to call MessageUnpacker#reset when the source is different from the previous one.
+            Object cachedSrc = messageUnpackerTuple.first();
+            if (StreamReadFeature.AUTO_CLOSE_SOURCE.enabledIn(streamReadFeatures) || cachedSrc != src || src instanceof byte[]) {
+                // reset() replaces the internal MessageBufferInput and clears the unpacker's
+                // internal read buffer to EMPTY_BUFFER. The old ArrayBufferInput becomes
+                // unreachable here (we discard the return value), so its byte[] is GC-eligible.
+                messageUnpackerTuple.second().reset(input);
+            }
+            messageUnpacker = messageUnpackerTuple.second();
+        }
+        messageUnpackerHolder.set(new Tuple<>(src, messageUnpacker));
+        ownsThreadLocalUnpacker = true;
+    }
+
+    public void setExtensionTypeCustomDeserializers(ExtensionTypeCustomDeserializers extTypeCustomDesers)
+    {
+        this.extTypeCustomDesers = extTypeCustomDesers;
+    }
+
+    @Override
+    public Version version()
+    {
+        return PackageVersion.VERSION;
+    }
+
+    private String unpackString(MessageUnpacker messageUnpacker) throws IOException
+    {
+        return messageUnpacker.unpackString();
+    }
+
+    @Override
+    public JsonToken nextToken() throws JacksonException
+    {
+        try {
+            return _nextToken();
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+    }
+
+    private JsonToken _nextToken() throws IOException
+    {
+        type = null;
+        tokenPosition = messageUnpacker.getTotalReadBytes();
+
+        boolean isObjectValueSet = streamReadContext.inObject() && _currToken != JsonToken.PROPERTY_NAME;
+        if (isObjectValueSet) {
+            if (!streamReadContext.expectMoreValues()) {
+                streamReadContext = streamReadContext.getParent();
+                return _updateToken(JsonToken.END_OBJECT);
+            }
+        }
+        else if (streamReadContext.inArray()) {
+            if (!streamReadContext.expectMoreValues()) {
+                streamReadContext = streamReadContext.getParent();
+                return _updateToken(JsonToken.END_ARRAY);
+            }
+        }
+
+        if (!messageUnpacker.hasNext()) {
+            if (streamReadContext.inRoot()) {
+                return null;
+            }
+            throw new UnexpectedEndOfInputException(this, null, null);
+        }
+
+        MessageFormat format = messageUnpacker.getNextFormat();
+        ValueType valueType = format.getValueType();
+
+        JsonToken nextToken;
+        switch (valueType) {
+            case STRING:
+                type = Type.STRING;
+                stringValue = unpackString(messageUnpacker);
+                _streamReadConstraints.validateStringLength(stringValue.length());
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(stringValue);
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = JsonToken.VALUE_STRING;
+                }
+                break;
+            case INTEGER:
+                Object v;
+                switch (format) {
+                    case UINT64:
+                        BigInteger bi = messageUnpacker.unpackBigInteger();
+                        if (0 <= bi.compareTo(LONG_MIN) && bi.compareTo(LONG_MAX) <= 0) {
+                            type = Type.LONG;
+                            longValue = bi.longValue();
+                            v = longValue;
+                        }
+                        else {
+                            type = Type.BIG_INT;
+                            biValue = bi;
+                            v = biValue;
+                        }
+                        break;
+                    default:
+                        long l = messageUnpacker.unpackLong();
+                        if (Integer.MIN_VALUE <= l && l <= Integer.MAX_VALUE) {
+                            type = Type.INT;
+                            intValue = (int) l;
+                            v = intValue;
+                        }
+                        else {
+                            type = Type.LONG;
+                            longValue = l;
+                            v = longValue;
+                        }
+                        break;
+                }
+
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(String.valueOf(v));
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = JsonToken.VALUE_NUMBER_INT;
+                }
+                break;
+            case NIL:
+                type = Type.NULL;
+                messageUnpacker.unpackNil();
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(null);
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = JsonToken.VALUE_NULL;
+                }
+                break;
+            case BOOLEAN:
+                boolean b = messageUnpacker.unpackBoolean();
+                type = Type.BOOL;
+                booleanValue = b;
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(Boolean.toString(b));
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = b ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
+                }
+                break;
+            case FLOAT:
+                type = Type.DOUBLE;
+                doubleValue = messageUnpacker.unpackDouble();
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(String.valueOf(doubleValue));
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = JsonToken.VALUE_NUMBER_FLOAT;
+                }
+                break;
+            case BINARY:
+                type = Type.BYTES;
+                int len = messageUnpacker.unpackBinaryHeader();
+                _streamReadConstraints.validateStringLength(len);
+                bytesValue = messageUnpacker.readPayload(len);
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(new String(bytesValue, MessagePack.UTF8));
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = JsonToken.VALUE_EMBEDDED_OBJECT;
+                }
+                break;
+            case ARRAY:
+                nextToken = JsonToken.START_ARRAY;
+                streamReadContext = streamReadContext.createChildArrayContext(messageUnpacker.unpackArrayHeader());
+                _streamReadConstraints.validateNestingDepth(streamReadContext.getNestingDepth());
+                break;
+            case MAP:
+                nextToken = JsonToken.START_OBJECT;
+                streamReadContext = streamReadContext.createChildObjectContext(messageUnpacker.unpackMapHeader());
+                _streamReadConstraints.validateNestingDepth(streamReadContext.getNestingDepth());
+                break;
+            case EXTENSION:
+                type = Type.EXT;
+                ExtensionTypeHeader header = messageUnpacker.unpackExtensionTypeHeader();
+                _streamReadConstraints.validateStringLength(header.getLength());
+                extensionTypeValue = new MessagePackExtensionType(header.getType(), messageUnpacker.readPayload(header.getLength()));
+                if (isObjectValueSet) {
+                    streamReadContext.setCurrentName(deserializedExtensionTypeValue().toString());
+                    nextToken = JsonToken.PROPERTY_NAME;
+                }
+                else {
+                    nextToken = JsonToken.VALUE_EMBEDDED_OBJECT;
+                }
+                break;
+            default:
+                nextToken = _reportError("Unexpected MessagePack format type: " + valueType);
+        }
+        currentPosition = messageUnpacker.getTotalReadBytes();
+
+        _updateToken(nextToken);
+
+        return nextToken;
+    }
+
+    @Override
+    protected void _handleEOF()
+    {
+    }
+
+    @Override
+    public String getString()
+    {
+        if (type == null) {
+            return _currToken == null ? null : _currToken.asString();
+        }
+        switch (type) {
+            case STRING:
+                return stringValue;
+            case BYTES:
+                return new String(bytesValue, MessagePack.UTF8);
+            case INT:
+                return String.valueOf(intValue);
+            case LONG:
+                return String.valueOf(longValue);
+            case DOUBLE:
+                return String.valueOf(doubleValue);
+            case BOOL:
+                return Boolean.toString(booleanValue);
+            case BIG_INT:
+                return String.valueOf(biValue);
+            case EXT:
+                try {
+                    return deserializedExtensionTypeValue().toString();
+                }
+                catch (IOException e) {
+                    throw _wrapIOFailure(e);
+                }
+            case NULL:
+                return "null";
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public char[] getStringCharacters()
+    {
+        return getString().toCharArray();
+    }
+
+    @Override
+    public boolean hasStringCharacters()
+    {
+        return false;
+    }
+
+    @Override
+    public int getStringLength()
+    {
+        return getString().length();
+    }
+
+    @Override
+    public int getStringOffset()
+    {
+        return 0;
+    }
+
+    @Override
+    public byte[] getBinaryValue(Base64Variant b64variant)
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not of binary type");
+        }
+        switch (type) {
+            case BYTES:
+                return bytesValue;
+            case STRING:
+                return stringValue.getBytes(MessagePack.UTF8);
+            case EXT:
+                return extensionTypeValue.getData();
+            case INT:
+            case LONG:
+            case DOUBLE:
+            case BOOL:
+            case BIG_INT:
+            case NULL:
+                return _reportError("Current token (" + _currToken + ") not of binary type");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public Number getNumberValue()
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return intValue;
+            case LONG:
+                return longValue;
+            case DOUBLE:
+                return doubleValue;
+            case BIG_INT:
+                return biValue;
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public int getIntValue()
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return intValue;
+            case LONG:
+                if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+                    return _reportError("Numeric value (" + longValue + ") out of range for `int`");
+                }
+                return (int) longValue;
+            case DOUBLE:
+                if (!Double.isFinite(doubleValue)) {
+                    return _reportError("Cannot convert non-finite double (" + doubleValue + ") to `int`");
+                }
+                if (doubleValue < Integer.MIN_VALUE || doubleValue > Integer.MAX_VALUE) {
+                    return _reportError("Numeric value (" + doubleValue + ") out of range for `int`");
+                }
+                return (int) doubleValue;
+            case BIG_INT:
+                try {
+                    return biValue.intValueExact();
+                }
+                catch (ArithmeticException e) {
+                    return _reportError("Numeric value (" + biValue + ") out of range for `int`");
+                }
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public long getLongValue()
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return intValue;
+            case LONG:
+                return longValue;
+            case DOUBLE:
+                if (!Double.isFinite(doubleValue)) {
+                    return _reportError("Cannot convert non-finite double (" + doubleValue + ") to `long`");
+                }
+                // (double)Long.MAX_VALUE rounds up to 2^63; use >= to reject 2^63 itself.
+                if (doubleValue < Long.MIN_VALUE || doubleValue >= (double) Long.MAX_VALUE) {
+                    return _reportError("Numeric value (" + doubleValue + ") out of range for `long`");
+                }
+                return (long) doubleValue;
+            case BIG_INT:
+                try {
+                    return biValue.longValueExact();
+                }
+                catch (ArithmeticException e) {
+                    return _reportError("Numeric value (" + biValue + ") out of range for `long`");
+                }
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public BigInteger getBigIntegerValue()
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return BigInteger.valueOf(intValue);
+            case LONG:
+                return BigInteger.valueOf(longValue);
+            case DOUBLE:
+                if (!Double.isFinite(doubleValue)) {
+                    return _reportError("Cannot convert non-finite double (" + doubleValue + ") to BigInteger");
+                }
+                return BigDecimal.valueOf(doubleValue).toBigInteger(); // truncates fractional part
+            case BIG_INT:
+                return biValue;
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public float getFloatValue()
+    {
+        // No bounds/range check: a finite double or large BigInteger may overflow to
+        // Float.POSITIVE_INFINITY. This is intentional — same as ParserBase and CBORParser.
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return (float) intValue;
+            case LONG:
+                return (float) longValue;
+            case DOUBLE:
+                return (float) doubleValue;
+            case BIG_INT:
+                return biValue.floatValue();
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public double getDoubleValue()
+    {
+        // No bounds/range check: large BigInteger may overflow to Double.POSITIVE_INFINITY,
+        // and large long values may lose precision. Intentional — same as ParserBase.
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return intValue;
+            case LONG:
+                return (double) longValue;
+            case DOUBLE:
+                return doubleValue;
+            case BIG_INT:
+                return biValue.doubleValue();
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public BigDecimal getDecimalValue()
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+        }
+        switch (type) {
+            case INT:
+                return BigDecimal.valueOf(intValue);
+            case LONG:
+                return BigDecimal.valueOf(longValue);
+            case DOUBLE:
+                if (!Double.isFinite(doubleValue)) {
+                    return _reportError("Cannot convert non-finite double (" + doubleValue + ") to BigDecimal");
+                }
+                return BigDecimal.valueOf(doubleValue);
+            case BIG_INT:
+                return new BigDecimal(biValue);
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return _reportError("Current token (" + _currToken + ") not numeric, cannot use numeric value accessors");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    private Object deserializedExtensionTypeValue()
+            throws IOException
+    {
+        if (extTypeCustomDesers != null) {
+            ExtensionTypeCustomDeserializers.Deser deser = extTypeCustomDesers.getDeser(extensionTypeValue.getType());
+            if (deser != null) {
+                return deser.deserialize(extensionTypeValue.getData());
+            }
+        }
+        return extensionTypeValue;
+    }
+
+    @Override
+    public Object getEmbeddedObject()
+    {
+        if (type == null) {
+            return _reportError("Current token (" + _currToken + ") not of embeddable type");
+        }
+        switch (type) {
+            case BYTES:
+                return bytesValue;
+            case EXT:
+                try {
+                    return deserializedExtensionTypeValue();
+                }
+                catch (IOException e) {
+                    throw _wrapIOFailure(e);
+                }
+            case INT:
+            case LONG:
+            case DOUBLE:
+            case BOOL:
+            case BIG_INT:
+            case STRING:
+            case NULL:
+                return _reportError("Current token (" + _currToken + ") not of embeddable type");
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    public NumberType getNumberType()
+    {
+        if (type == null) {
+            return null;
+        }
+        switch (type) {
+            case INT:
+                return NumberType.INT;
+            case LONG:
+                return NumberType.LONG;
+            case DOUBLE:
+                return NumberType.DOUBLE;
+            case BIG_INT:
+                return NumberType.BIG_INTEGER;
+            case NULL:
+            case BOOL:
+            case STRING:
+            case BYTES:
+            case EXT:
+                return null;
+            default:
+                return _reportError("Unexpected MessagePack value type: " + type);
+        }
+    }
+
+    @Override
+    protected void _closeInput() throws IOException
+    {
+        if (StreamReadFeature.AUTO_CLOSE_SOURCE.enabledIn(_streamReadFeatures)) {
+            messageUnpacker.close();
+        }
+        if (ownsThreadLocalUnpacker) {
+            Tuple<Object, MessageUnpacker> tuple = messageUnpackerHolder.get();
+            if (tuple != null) {
+                if (tuple.first() instanceof byte[]) {
+                    // close() calls ArrayBufferInput.close() which sets buffer = null,
+                    // releasing the byte[] payload reference held by the unpacker's input.
+                    // The unpacker itself is kept alive for reuse on the next parse.
+                    tuple.second().close();
+                    messageUnpackerHolder.set(new Tuple<>(null, tuple.second()));
+                }
+                else if (StreamReadFeature.AUTO_CLOSE_SOURCE.enabledIn(_streamReadFeatures)) {
+                    // Stream is already closed above; release the reference so it doesn't
+                    // linger on the thread until the next parse.
+                    messageUnpackerHolder.set(new Tuple<>(null, tuple.second()));
+                }
+                // else: InputStream with AUTO_CLOSE_SOURCE disabled — keep the reference
+                // so the next parse on the same thread can detect same-stream reuse and
+                // avoid resetting the unpacker (which would discard its read-ahead buffer).
+            }
+        }
+    }
+
+    @Override
+    protected void _releaseBuffers()
+    {
+    }
+
+    @Override
+    public boolean isClosed()
+    {
+        return isClosed;
+    }
+
+    @Override
+    public void close()
+    {
+        if (isClosed) {
+            return;
+        }
+        // Parsers are single-threaded by contract; close() is expected on the same
+        // thread that created the parser. Cross-thread close is not a supported use case.
+        try {
+            _closeInput();
+        }
+        catch (IOException e) {
+            throw _wrapIOFailure(e);
+        }
+        finally {
+            isClosed = true;
+        }
+    }
+
+    @Override
+    public TokenStreamContext streamReadContext()
+    {
+        return streamReadContext;
+    }
+
+    @Override
+    public TokenStreamLocation currentTokenLocation()
+    {
+        // columnNr repurposed as byte offset; truncates for inputs > 2 GB
+        return new TokenStreamLocation(ioContext.contentReference(), tokenPosition, -1, (int) tokenPosition);
+    }
+
+    @Override
+    public TokenStreamLocation currentLocation()
+    {
+        // columnNr repurposed as byte offset; truncates for inputs > 2 GB
+        return new TokenStreamLocation(ioContext.contentReference(), currentPosition, -1, (int) currentPosition);
+    }
+
+    @Override
+    public String currentName()
+    {
+        // Simple, but need to look for START_OBJECT/ARRAY's "off-by-one" thing:
+        if (_currToken == JsonToken.START_OBJECT || _currToken == JsonToken.START_ARRAY) {
+            MessagePackReadContext parent = streamReadContext.getParent();
+            return parent.currentName();
+        }
+        return streamReadContext.currentName();
+    }
+
+    @Override
+    public Object streamReadInputSource()
+    {
+        return ioContext.contentReference().getRawContent();
+    }
+
+    @Override
+    public Object currentValue()
+    {
+        return streamReadContext.currentValue();
+    }
+
+    @Override
+    public void assignCurrentValue(Object v)
+    {
+        streamReadContext.assignCurrentValue(v);
+    }
+
+    @Override
+    public boolean isNaN()
+    {
+        if (type == Type.DOUBLE) {
+            return Double.isNaN(doubleValue) || Double.isInfinite(doubleValue);
+        }
+        return false;
+    }
+
+    public boolean isCurrentFieldId()
+    {
+        return this.type == Type.INT || this.type == Type.LONG;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackReadContext.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackReadContext.java
@@ -1,0 +1,213 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.TokenStreamLocation;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.core.io.ContentReference;
+import tools.jackson.core.json.DupDetector;
+
+/**
+ * Replacement of {@link tools.jackson.core.json.JsonReadContext}
+ * to support features needed by MessagePack format.
+ */
+public final class MessagePackReadContext
+    extends TokenStreamContext
+{
+    protected final MessagePackReadContext parent;
+
+    protected final DupDetector dups;
+
+    /**
+     * For fixed-size Arrays, Objects, this indicates expected number of entries.
+     */
+    protected int expEntryCount;
+
+    protected String currentName;
+
+    protected Object currentValue;
+
+    protected MessagePackReadContext child = null;
+
+    public MessagePackReadContext(MessagePackReadContext parent, DupDetector dups,
+                                  int type, int expEntryCount)
+    {
+        super();
+        this.parent = parent;
+        this.dups = dups;
+        _type = type;
+        this.expEntryCount = expEntryCount;
+        _index = -1;
+        _nestingDepth = parent == null ? 0 : parent._nestingDepth + 1;
+    }
+
+    protected void reset(int type, int expEntryCount)
+    {
+        _type = type;
+        this.expEntryCount = expEntryCount;
+        _index = -1;
+        currentName = null;
+        currentValue = null;
+        if (dups != null) {
+            dups.reset();
+        }
+    }
+
+    @Override
+    public Object currentValue()
+    {
+        return currentValue;
+    }
+
+    @Override
+    public void assignCurrentValue(Object v)
+    {
+        currentValue = v;
+    }
+
+    public static MessagePackReadContext createRootContext(DupDetector dups)
+    {
+        return new MessagePackReadContext(null, dups, TYPE_ROOT, -1);
+    }
+
+    public MessagePackReadContext createChildArrayContext(int expEntryCount)
+    {
+        MessagePackReadContext ctxt = child;
+        if (ctxt == null) {
+            ctxt = new MessagePackReadContext(this,
+                    (dups == null) ? null : dups.child(),
+                            TYPE_ARRAY, expEntryCount);
+            child = ctxt;
+        }
+        else {
+            ctxt.reset(TYPE_ARRAY, expEntryCount);
+        }
+        return ctxt;
+    }
+
+    public MessagePackReadContext createChildObjectContext(int expEntryCount)
+    {
+        MessagePackReadContext ctxt = child;
+        if (ctxt == null) {
+            ctxt = new MessagePackReadContext(this,
+                    (dups == null) ? null : dups.child(),
+                    TYPE_OBJECT, expEntryCount);
+            child = ctxt;
+            return ctxt;
+        }
+        ctxt.reset(TYPE_OBJECT, expEntryCount);
+        return ctxt;
+    }
+
+    @Override
+    public String currentName()
+    {
+        return currentName;
+    }
+
+    @Override
+    public MessagePackReadContext getParent()
+    {
+        return parent;
+    }
+
+    public boolean hasExpectedLength()
+    {
+        return (expEntryCount >= 0);
+    }
+
+    public int getExpectedLength()
+    {
+        return expEntryCount;
+    }
+
+    public boolean isEmpty()
+    {
+        return expEntryCount == 0;
+    }
+
+    public int getRemainingExpectedLength()
+    {
+        int diff = expEntryCount - _index;
+        return Math.max(0, diff);
+    }
+
+    public boolean acceptsBreakMarker()
+    {
+        return (expEntryCount < 0) && _type != TYPE_ROOT;
+    }
+
+    public boolean expectMoreValues()
+    {
+        if (++_index == expEntryCount) {
+            return false;
+        }
+        return true;
+    }
+
+    public TokenStreamLocation startLocation(ContentReference srcRef)
+    {
+        return new TokenStreamLocation(srcRef, 1L, -1, -1);
+    }
+
+    public void setCurrentName(String name)
+    {
+        currentName = name;
+        if (dups != null) {
+            _checkDup(dups, name);
+        }
+    }
+
+    private void _checkDup(DupDetector dd, String name)
+    {
+        // Null names (nil map keys) cannot be duplicate-checked via DupDetector
+        // because DupDetector.isDup(null) NPEs when a prior non-null name exists.
+        if (name != null && dd.isDup(name)) {
+            throw new StreamReadException(null,
+                    "Duplicate field '" + name + "'", dd.findLocation());
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder(64);
+        switch (_type) {
+        case TYPE_ROOT:
+            sb.append("/");
+            break;
+        case TYPE_ARRAY:
+            sb.append('[');
+            sb.append(getCurrentIndex());
+            sb.append(']');
+            break;
+        case TYPE_OBJECT:
+            sb.append('{');
+            if (currentName != null) {
+                sb.append('"');
+                sb.append(currentName.replace("\\", "\\\\").replace("\"", "\\\""));
+                sb.append('"');
+            }
+            else {
+                sb.append('?');
+            }
+            sb.append('}');
+            break;
+        }
+        return sb.toString();
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackSerializedString.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackSerializedString.java
@@ -1,0 +1,142 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.SerializableString;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class MessagePackSerializedString
+        implements SerializableString
+{
+    private static final Charset UTF8 = StandardCharsets.UTF_8;
+    private final Object value;
+
+    public MessagePackSerializedString(Object value)
+    {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue()
+    {
+        return value == null ? null : value.toString();
+    }
+
+    @Override
+    public int charLength()
+    {
+        String v = getValue();
+        return v == null ? 0 : v.length();
+    }
+
+    @Override
+    public char[] asQuotedChars()
+    {
+        String v = getValue();
+        return v == null ? new char[0] : v.toCharArray();
+    }
+
+    @Override
+    public byte[] asUnquotedUTF8()
+    {
+        String v = getValue();
+        return v == null ? new byte[0] : v.getBytes(UTF8);
+    }
+
+    @Override
+    public byte[] asQuotedUTF8()
+    {
+        return asUnquotedUTF8();
+    }
+
+    @Override
+    public int appendQuotedUTF8(byte[] bytes, int i)
+    {
+        return appendUnquotedUTF8(bytes, i);
+    }
+
+    @Override
+    public int appendQuoted(char[] chars, int i)
+    {
+        return appendUnquoted(chars, i);
+    }
+
+    @Override
+    public int appendUnquotedUTF8(byte[] bytes, int i)
+    {
+        byte[] utf8 = asUnquotedUTF8();
+        if (utf8.length > bytes.length - i) {
+            return -1;
+        }
+        System.arraycopy(utf8, 0, bytes, i, utf8.length);
+        return utf8.length;
+    }
+
+    @Override
+    public int appendUnquoted(char[] chars, int i)
+    {
+        String v = getValue();
+        if (v == null) {
+            return 0;
+        }
+        if (v.length() > chars.length - i) {
+            return -1;
+        }
+        v.getChars(0, v.length(), chars, i);
+        return v.length();
+    }
+
+    @Override
+    public int writeQuotedUTF8(OutputStream outputStream) throws IOException
+    {
+        return writeUnquotedUTF8(outputStream);
+    }
+
+    @Override
+    public int writeUnquotedUTF8(OutputStream outputStream) throws IOException
+    {
+        byte[] utf8 = asUnquotedUTF8();
+        outputStream.write(utf8);
+        return utf8.length;
+    }
+
+    @Override
+    public int putQuotedUTF8(ByteBuffer byteBuffer)
+    {
+        return putUnquotedUTF8(byteBuffer);
+    }
+
+    @Override
+    public int putUnquotedUTF8(ByteBuffer byteBuffer)
+    {
+        byte[] utf8 = asUnquotedUTF8();
+        if (utf8.length > byteBuffer.remaining()) {
+            return -1;
+        }
+        byteBuffer.put(utf8);
+        return utf8.length;
+    }
+
+    public Object getRawValue()
+    {
+        return value;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackSerializerFactory.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackSerializerFactory.java
@@ -1,0 +1,44 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.cfg.SerializerFactoryConfig;
+import tools.jackson.databind.ser.BeanSerializerFactory;
+
+public class MessagePackSerializerFactory
+        extends BeanSerializerFactory
+{
+    public MessagePackSerializerFactory()
+    {
+        super(null);
+    }
+
+    public MessagePackSerializerFactory(SerializerFactoryConfig config)
+    {
+        super(config);
+    }
+
+    private static final MessagePackKeySerializer KEY_SERIALIZER = new MessagePackKeySerializer();
+
+    @Override
+    public ValueSerializer<Object> createKeySerializer(SerializationContext ctxt, JavaType keyType)
+    {
+        return KEY_SERIALIZER;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackWriteContext.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/MessagePackWriteContext.java
@@ -1,0 +1,139 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.exc.StreamWriteException;
+import tools.jackson.core.json.DupDetector;
+
+class MessagePackWriteContext extends TokenStreamContext
+{
+    private final MessagePackWriteContext parent;
+    private MessagePackWriteContext childToRecycle;
+    private DupDetector dups;
+    private String currentName;
+    private Object currentValue;
+    // For TYPE_OBJECT: true after writeName (expecting value), false after writeValue (expecting name)
+    private boolean gotName;
+
+    private MessagePackWriteContext(int type, MessagePackWriteContext parent, DupDetector dups)
+    {
+        super(type, -1);
+        this.parent = parent;
+        this.dups = dups;
+    }
+
+    private MessagePackWriteContext reset(int type, Object value)
+    {
+        _type = type;
+        _index = -1;
+        gotName = false;
+        currentName = null;
+        currentValue = value;
+        if (dups != null) {
+            dups.reset();
+        }
+        return this;
+    }
+
+    static MessagePackWriteContext createRootContext(DupDetector dups)
+    {
+        return new MessagePackWriteContext(TYPE_ROOT, null, dups);
+    }
+
+    MessagePackWriteContext createChildArrayContext(Object value)
+    {
+        MessagePackWriteContext ctx = childToRecycle;
+        if (ctx == null) {
+            ctx = new MessagePackWriteContext(TYPE_ARRAY, this, dups == null ? null : dups.child());
+            childToRecycle = ctx;
+        }
+        return ctx.reset(TYPE_ARRAY, value);
+    }
+
+    MessagePackWriteContext createChildObjectContext(Object value)
+    {
+        MessagePackWriteContext ctx = childToRecycle;
+        if (ctx == null) {
+            ctx = new MessagePackWriteContext(TYPE_OBJECT, this, dups == null ? null : dups.child());
+            childToRecycle = ctx;
+        }
+        return ctx.reset(TYPE_OBJECT, value);
+    }
+
+    @Override
+    public MessagePackWriteContext getParent()
+    {
+        return parent;
+    }
+
+    boolean isExpectingValue()
+    {
+        return _type == TYPE_OBJECT && gotName;
+    }
+
+    boolean writeValue()
+    {
+        if (_type == TYPE_OBJECT) {
+            if (!gotName) {
+                return false;
+            }
+            gotName = false;
+        }
+        ++_index;
+        return true;
+    }
+
+    boolean writeName(String name) throws StreamWriteException
+    {
+        if (_type != TYPE_OBJECT || gotName) {
+            return false;
+        }
+        currentName = name;
+        gotName = true;
+        if (dups != null) {
+            _checkDup(name);
+        }
+        return true;
+    }
+
+    private void _checkDup(String name) throws StreamWriteException
+    {
+        // Null names (nil map keys) cannot be duplicate-checked via DupDetector
+        // because DupDetector.isDup(null) NPEs when a prior non-null name exists.
+        if (name != null && dups.isDup(name)) {
+            throw new StreamWriteException(null, "Duplicate Object property \"" + name + "\"");
+        }
+    }
+
+    @Override
+    public String currentName()
+    {
+        return currentName;
+    }
+
+    @Override
+    public Object currentValue()
+    {
+        return currentValue;
+    }
+
+    @Override
+    public void assignCurrentValue(Object v)
+    {
+        currentValue = v;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/PackageVersion.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/PackageVersion.java
@@ -1,0 +1,30 @@
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.Version;
+import tools.jackson.core.Versioned;
+
+public class PackageVersion
+        implements Versioned
+{
+    public static final Version VERSION = new Version(0, 9, 12, null, "org.msgpack", "jackson-dataformat-msgpack-jackson3");
+
+    @Override
+    public Version version()
+    {
+        return VERSION;
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/TimestampExtensionModule.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/TimestampExtensionModule.java
@@ -1,0 +1,107 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.StdSerializer;
+import org.msgpack.core.ExtensionTypeHeader;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+public class TimestampExtensionModule
+{
+    public static final byte EXT_TYPE = -1;
+    public static final SimpleModule INSTANCE = new SimpleModule("msgpack-ext-timestamp");
+
+    static {
+        INSTANCE.addSerializer(Instant.class, new InstantSerializer(Instant.class));
+        INSTANCE.addDeserializer(Instant.class, new InstantDeserializer(Instant.class));
+    }
+
+    private static class InstantSerializer extends StdSerializer<Instant>
+    {
+        protected InstantSerializer(Class<Instant> t)
+        {
+            super(t);
+        }
+
+        @Override
+        public void serialize(Instant value, JsonGenerator gen, SerializationContext provider)
+        {
+            try {
+                // Per-call allocation is a known limitation carried from the v2 module.
+                // Manually encoding the timestamp bytes would avoid it but duplicates
+                // msgpack-core's timestamp logic. Tracked as a future optimization.
+                ByteArrayOutputStream os = new ByteArrayOutputStream();
+                try (MessagePacker packer = MessagePack.newDefaultPacker(os)) {
+                    packer.packTimestamp(value);
+                }
+                try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(os.toByteArray())) {
+                    ExtensionTypeHeader header = unpacker.unpackExtensionTypeHeader();
+                    byte[] bytes = unpacker.readPayload(header.getLength());
+
+                    MessagePackExtensionType extensionType = new MessagePackExtensionType(EXT_TYPE, bytes);
+                    gen.writePOJO(extensionType);
+                }
+            }
+            catch (IOException e) {
+                throw _wrapIOFailure(provider, e);
+            }
+        }
+    }
+
+    private static class InstantDeserializer extends StdDeserializer<Instant>
+    {
+        protected InstantDeserializer(Class<?> vc)
+        {
+            super(vc);
+        }
+
+        @Override
+        public Instant deserialize(JsonParser p, DeserializationContext ctxt)
+        {
+            try {
+                // Per-call allocation is a known limitation — see serialize() above.
+                MessagePackExtensionType ext = p.readValueAs(MessagePackExtensionType.class);
+                if (ext.getType() != EXT_TYPE) {
+                    ctxt.reportInputMismatch(Instant.class,
+                            "Unexpected extension type (0x%X) for Instant object", ext.getType() & 0xFF);
+                    return null; // unreachable
+                }
+                try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(ext.getData())) {
+                    return unpacker.unpackTimestamp(new ExtensionTypeHeader(EXT_TYPE, ext.getData().length));
+                }
+            }
+            catch (IOException e) {
+                throw _wrapIOFailure(ctxt, e);
+            }
+        }
+    }
+
+    private TimestampExtensionModule()
+    {
+    }
+}

--- a/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/Tuple.java
+++ b/msgpack-jackson3/src/main/java/org/msgpack/jackson/dataformat/Tuple.java
@@ -1,0 +1,38 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+public class Tuple<F, S>
+{
+    private final F first;
+    private final S second;
+
+    public Tuple(F first, S second)
+    {
+        this.first = first;
+        this.second = second;
+    }
+
+    public F first()
+    {
+        return first;
+    }
+
+    public S second()
+    {
+        return second;
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/ExampleOfTypeInformationSerDe.java
@@ -1,0 +1,171 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.TreeNode;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ExampleOfTypeInformationSerDe
+        extends MessagePackDataformatTestBase
+{
+    static class A
+    {
+        private List<String> list = new ArrayList<String>();
+
+        public List<String> getList()
+        {
+            return list;
+        }
+
+        public void setList(List<String> list)
+        {
+            this.list = list;
+        }
+    }
+
+    static class B
+    {
+        private String str;
+
+        public String getStr()
+        {
+            return str;
+        }
+
+        public void setStr(String str)
+        {
+            this.str = str;
+        }
+    }
+
+    @JsonSerialize(using = ObjectContainerSerializer.class)
+    @JsonDeserialize(using = ObjectContainerDeserializer.class)
+    static class ObjectContainer
+    {
+        private final Map<String, Object> objects;
+
+        public ObjectContainer(Map<String, Object> objects)
+        {
+            this.objects = objects;
+        }
+
+        public Map<String, Object> getObjects()
+        {
+            return objects;
+        }
+    }
+
+    static class ObjectContainerSerializer
+            extends ValueSerializer<ObjectContainer>
+    {
+        @Override
+        public void serialize(ObjectContainer value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeStartObject();
+            HashMap<String, String> metadata = new HashMap<String, String>();
+            for (Map.Entry<String, Object> entry : value.getObjects().entrySet()) {
+                metadata.put(entry.getKey(), entry.getValue().getClass().getName());
+            }
+            gen.writePOJOProperty("__metadata", metadata);
+            gen.writePOJOProperty("objects", value.getObjects());
+            gen.writeEndObject();
+        }
+    }
+
+    static class ObjectContainerDeserializer
+        extends ValueDeserializer<ObjectContainer>
+    {
+        @Override
+        public ObjectContainer deserialize(JsonParser p, DeserializationContext ctxt)
+                throws JacksonException
+        {
+            ObjectContainer objectContainer = new ObjectContainer(new HashMap<String, Object>());
+            TreeNode treeNode = p.readValueAsTree();
+
+            Map<String, String> metadata = treeNode.get("__metadata")
+                    .traverse(p.objectReadContext())
+                    .readValueAs(new TypeReference<Map<String, String>>() {});
+            TreeNode dataMapTree = treeNode.get("objects");
+            for (Map.Entry<String, String> entry : metadata.entrySet()) {
+                try {
+                    Object o = dataMapTree.get(entry.getKey())
+                            .traverse(p.objectReadContext())
+                            .readValueAs(Class.forName(entry.getValue()));
+                    objectContainer.getObjects().put(entry.getKey(), o);
+                }
+                catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Failed to deserialize: " + entry, e);
+                }
+            }
+
+            return objectContainer;
+        }
+    }
+
+    @Test
+    public void test()
+            throws IOException
+    {
+        ObjectContainer objectContainer = new ObjectContainer(new HashMap<String, Object>());
+        {
+            A a = new A();
+            a.setList(Arrays.asList("first", "second", "third"));
+            objectContainer.getObjects().put("a", a);
+
+            B b = new B();
+            b.setStr("hello world");
+            objectContainer.getObjects().put("b", b);
+
+            Double pi = 3.14;
+            objectContainer.getObjects().put("pi", pi);
+        }
+
+        ObjectMapper objectMapper = new MessagePackMapper(new MessagePackFactory());
+        byte[] bytes = objectMapper.writeValueAsBytes(objectContainer);
+        ObjectContainer restored = objectMapper.readValue(bytes, ObjectContainer.class);
+
+        {
+            assertEquals(3, restored.getObjects().size());
+            A a = (A) restored.getObjects().get("a");
+            assertArrayEquals(new String[] {"first", "second", "third"}, a.getList().toArray());
+            B b = (B) restored.getObjects().get("b");
+            assertEquals("hello world", b.getStr());
+            assertEquals(3.14, restored.getObjects().get("pi"));
+        }
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForFieldIdTest.java
@@ -1,0 +1,135 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.KeyDeserializer;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.NullValueProvider;
+import tools.jackson.databind.deser.jdk.JDKValueInstantiators;
+import tools.jackson.databind.deser.jdk.MapDeserializer;
+import tools.jackson.databind.jsontype.TypeDeserializer;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.type.TypeFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashMap;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MessagePackDataformatForFieldIdTest
+{
+    static class MessagePackMapDeserializer extends MapDeserializer
+    {
+        public static KeyDeserializer keyDeserializer = new KeyDeserializer()
+        {
+            @Override
+            public Object deserializeKey(String s, DeserializationContext deserializationContext)
+                    throws JacksonException
+            {
+                JsonParser parser = deserializationContext.getParser();
+                if (parser instanceof MessagePackParser) {
+                    MessagePackParser p = (MessagePackParser) parser;
+                    if (p.isCurrentFieldId()) {
+                        return Integer.valueOf(s);
+                    }
+                }
+                return s;
+            }
+        };
+
+        public MessagePackMapDeserializer()
+        {
+            super(
+                    TypeFactory.createDefaultInstance().constructMapType(Map.class, Object.class, Object.class),
+                    JDKValueInstantiators.findStdValueInstantiator(null, LinkedHashMap.class),
+                    keyDeserializer, null, null);
+        }
+
+        public MessagePackMapDeserializer(MapDeserializer src, KeyDeserializer keyDeser,
+                ValueDeserializer<Object> valueDeser, TypeDeserializer valueTypeDeser, NullValueProvider nuller,
+                Set<String> ignorable, Set<String> includable)
+        {
+            super(src, keyDeser, valueDeser, valueTypeDeser, nuller, ignorable, includable);
+        }
+
+        @Override
+        protected MapDeserializer withResolved(KeyDeserializer keyDeser, TypeDeserializer valueTypeDeser,
+                ValueDeserializer<?> valueDeser, NullValueProvider nuller, Set<String> ignorable,
+                Set<String> includable)
+        {
+            return new MessagePackMapDeserializer(this, keyDeser, (ValueDeserializer<Object>) valueDeser, valueTypeDeser,
+                    nuller, ignorable, includable);
+        }
+    }
+
+    @Test
+    public void testMixedKeys()
+            throws IOException
+    {
+        ObjectMapper mapper = MessagePackMapper.builder(
+                    new MessagePackFactory()
+                        .setSupportIntegerKeys(true)
+                )
+                .addModule(new SimpleModule()
+                .addDeserializer(Map.class, new MessagePackMapDeserializer()))
+                .build();
+
+        Map<Object, Object> map = new HashMap<>();
+        map.put(1, "one");
+        map.put("2", "two");
+
+        byte[] bytes = mapper.writeValueAsBytes(map);
+        Map<Object, Object> deserializedInit = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
+
+        Map<Object, Object> expected = new HashMap<>(map);
+        Map<Object, Object> actual = new HashMap<>(deserializedInit);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testMixedKeysBackwardsCompatible()
+            throws IOException
+    {
+        ObjectMapper mapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule()
+                .addDeserializer(Map.class, new MessagePackMapDeserializer()))
+                .build();
+
+        Map<Object, Object> map = new HashMap<>();
+        map.put(1, "one");
+        map.put("2", "two");
+
+        byte[] bytes = mapper.writeValueAsBytes(map);
+        Map<Object, Object> deserializedInit = mapper.readValue(bytes, new TypeReference<Map<Object, Object>>() {});
+
+        Map<Object, Object> expected = new HashMap<>();
+        expected.put("1", "one");
+        expected.put("2", "two");
+        Map<Object, Object> actual = new HashMap<>(deserializedInit);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatForPojoTest.java
@@ -1,0 +1,150 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessagePackDataformatForPojoTest
+        extends MessagePackDataformatTestBase
+{
+    @Test
+    public void testNormal()
+            throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(normalPojo);
+        NormalPojo value = objectMapper.readValue(bytes, NormalPojo.class);
+        assertEquals(normalPojo.s, value.getS());
+        assertEquals(normalPojo.bool, value.bool);
+        assertEquals(normalPojo.i, value.i);
+        assertEquals(normalPojo.l, value.l);
+        assertEquals(normalPojo.f, value.f, 0.000001f);
+        assertEquals(normalPojo.d, value.d, 0.000001f);
+        assertArrayEquals(normalPojo.b, value.b);
+        assertEquals(normalPojo.bi, value.bi);
+        assertEquals(normalPojo.suit, value.suit);
+        assertEquals(normalPojo.sMultibyte, value.sMultibyte);
+    }
+
+    @Test
+    public void testNestedList()
+            throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(nestedListPojo);
+        NestedListPojo value = objectMapper.readValue(bytes, NestedListPojo.class);
+        assertEquals(nestedListPojo.s, value.s);
+        assertArrayEquals(nestedListPojo.strs.toArray(), value.strs.toArray());
+    }
+
+    @Test
+    public void testNestedListComplex1()
+            throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(nestedListComplexPojo1);
+        NestedListComplexPojo1 value = objectMapper.readValue(bytes, NestedListComplexPojo1.class);
+        assertEquals(nestedListComplexPojo1.s, value.s);
+        assertEquals(1, nestedListComplexPojo1.foos.size());
+        assertEquals(nestedListComplexPojo1.foos.get(0).t, value.foos.get(0).t);
+    }
+
+    @Test
+    public void testNestedListComplex2()
+            throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(nestedListComplexPojo2);
+        NestedListComplexPojo2 value = objectMapper.readValue(bytes, NestedListComplexPojo2.class);
+        assertEquals(nestedListComplexPojo2.s, value.s);
+        assertEquals(2, nestedListComplexPojo2.foos.size());
+        assertEquals(nestedListComplexPojo2.foos.get(0).t, value.foos.get(0).t);
+        assertEquals(nestedListComplexPojo2.foos.get(1).t, value.foos.get(1).t);
+    }
+
+    @Test
+    public void testStrings()
+            throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(stringPojo);
+        StringPojo value = objectMapper.readValue(bytes, StringPojo.class);
+        assertEquals(stringPojo.shortSingleByte, value.shortSingleByte);
+        assertEquals(stringPojo.longSingleByte, value.longSingleByte);
+        assertEquals(stringPojo.shortMultiByte, value.shortMultiByte);
+        assertEquals(stringPojo.longMultiByte, value.longMultiByte);
+    }
+
+    @Test
+    public void testUsingCustomConstructor()
+            throws IOException
+    {
+        UsingCustomConstructorPojo orig = new UsingCustomConstructorPojo("komamitsu", 55);
+        byte[] bytes = objectMapper.writeValueAsBytes(orig);
+        UsingCustomConstructorPojo value = objectMapper.readValue(bytes, UsingCustomConstructorPojo.class);
+        assertEquals("komamitsu", value.name);
+        assertEquals(55, value.age);
+    }
+
+    @Test
+    public void testIgnoringProperties()
+            throws IOException
+    {
+        IgnoringPropertiesPojo orig = new IgnoringPropertiesPojo();
+        orig.internal = "internal";
+        orig.external = "external";
+        orig.setCode(1234);
+        byte[] bytes = objectMapper.writeValueAsBytes(orig);
+        IgnoringPropertiesPojo value = objectMapper.readValue(bytes, IgnoringPropertiesPojo.class);
+        assertEquals(0, value.getCode());
+        assertEquals(null, value.internal);
+        assertEquals("external", value.external);
+    }
+
+    @Test
+    public void testChangingPropertyNames()
+            throws IOException
+    {
+        ChangingPropertyNamesPojo orig = new ChangingPropertyNamesPojo();
+        orig.setTheName("komamitsu");
+        byte[] bytes = objectMapper.writeValueAsBytes(orig);
+        ChangingPropertyNamesPojo value = objectMapper.readValue(bytes, ChangingPropertyNamesPojo.class);
+        assertEquals("komamitsu", value.getTheName());
+    }
+
+    @Test
+    public void testSerializationWithoutSchema()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(factory)
+                .annotationIntrospector(new JsonArrayFormat())
+                .build();
+        byte[] bytes = objectMapper.writeValueAsBytes(complexPojo);
+        String schema = new String(bytes, Charset.forName("UTF-8"));
+        assertThat(schema, not(containsString("name")));
+        ComplexPojo value = objectMapper.readValue(bytes, ComplexPojo.class);
+        assertEquals("komamitsu", value.name);
+        assertEquals(20, value.age);
+        assertArrayEquals(complexPojo.values.toArray(), value.values.toArray());
+        assertEquals(complexPojo.grades.get("math"), value.grades.get("math"));
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatTestBase.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackDataformatTestBase.java
@@ -1,0 +1,289 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Collections;
+
+public class MessagePackDataformatTestBase
+{
+    protected MessagePackFactory factory;
+    protected ByteArrayOutputStream out;
+    protected ByteArrayInputStream in;
+    protected ObjectMapper objectMapper;
+    protected NormalPojo normalPojo;
+    protected NestedListPojo nestedListPojo;
+    protected NestedListComplexPojo1 nestedListComplexPojo1;
+    protected NestedListComplexPojo2 nestedListComplexPojo2;
+    protected StringPojo stringPojo;
+    protected TinyPojo tinyPojo;
+    protected ComplexPojo complexPojo;
+
+    @Before
+    public void setup()
+    {
+        factory = new MessagePackFactory();
+        objectMapper = new MessagePackMapper(factory);
+        out = new ByteArrayOutputStream();
+        in = new ByteArrayInputStream(new byte[4096]);
+
+        normalPojo = new NormalPojo();
+        normalPojo.setS("komamitsu");
+        normalPojo.bool = true;
+        normalPojo.i = Integer.MAX_VALUE;
+        normalPojo.l = Long.MIN_VALUE;
+        normalPojo.f = Float.MIN_VALUE;
+        normalPojo.d = Double.MAX_VALUE;
+        normalPojo.b = new byte[] {0x01, 0x02, (byte) 0xFE, (byte) 0xFF};
+        normalPojo.bi = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        normalPojo.suit = Suit.HEART;
+        normalPojo.sMultibyte = "text文字";
+
+        nestedListPojo = new NestedListPojo();
+        nestedListPojo.s = "a string";
+        nestedListPojo.strs = Arrays.asList("string#1", "string#2", "string#3");
+
+        tinyPojo = new TinyPojo();
+        tinyPojo.t = "t string";
+
+        nestedListComplexPojo1 = new NestedListComplexPojo1();
+        nestedListComplexPojo1.s = "a string";
+        nestedListComplexPojo1.foos = new ArrayList<>();
+        nestedListComplexPojo1.foos.add(tinyPojo);
+
+        nestedListComplexPojo2 = new NestedListComplexPojo2();
+        nestedListComplexPojo2.foos = new ArrayList<>();
+        nestedListComplexPojo2.foos.add(tinyPojo);
+        nestedListComplexPojo2.foos.add(tinyPojo);
+        nestedListComplexPojo2.s = "another string";
+
+        stringPojo = new StringPojo();
+        stringPojo.shortSingleByte = "hello";
+        stringPojo.longSingleByte = "helloworldhelloworldhelloworldhelloworldhelloworldhelloworldhelloworldhelloworld";
+        stringPojo.shortMultiByte = "こんにちは";
+        stringPojo.longMultiByte = "こんにちは、世界！！こんにちは、世界！！こんにちは、世界！！こんにちは、世界！！こんにちは、世界！！";
+
+        complexPojo = new ComplexPojo();
+        complexPojo.name = "komamitsu";
+        complexPojo.age = 20;
+        complexPojo.grades = Collections.singletonMap("math", 97);
+        complexPojo.values = Arrays.asList("one", "two", "three");
+    }
+
+    @After
+    public void teardown()
+    {
+        if (in != null) {
+            try {
+                in.close();
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (out != null) {
+            try {
+                out.close();
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public enum Suit
+    {
+        SPADE, HEART, DIAMOND, CLUB;
+    }
+
+    public static class NestedListPojo
+    {
+        public String s;
+        public List<String> strs;
+    }
+
+    public static class ComplexPojo
+    {
+        public String name;
+        public int age;
+        public List<String> values;
+        public Map<String, Integer> grades;
+    }
+
+    public static class TinyPojo
+    {
+        public String t;
+    }
+
+    public static class NestedListComplexPojo1
+    {
+        public String s;
+        public List<TinyPojo> foos;
+    }
+
+    public static class NestedListComplexPojo2
+    {
+        public List<TinyPojo> foos;
+        public String s;
+    }
+
+    public static class StringPojo
+    {
+        public String shortSingleByte;
+        public String longSingleByte;
+        public String shortMultiByte;
+        public String longMultiByte;
+    }
+
+    public static class NormalPojo
+    {
+        String s;
+        public boolean bool;
+        public int i;
+        public long l;
+        public Float f;
+        public Double d;
+        public byte[] b;
+        public BigInteger bi;
+        public Suit suit;
+        public String sMultibyte;
+
+        public String getS()
+        {
+            return s;
+        }
+
+        public void setS(String s)
+        {
+            this.s = s;
+        }
+    }
+
+    public static class BinKeyPojo
+    {
+        public byte[] b;
+        public String s;
+    }
+
+    public static class UsingCustomConstructorPojo
+    {
+        final String name;
+        final int age;
+
+        public UsingCustomConstructorPojo(@JsonProperty("name") String name, @JsonProperty("age") int age)
+        {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public int getAge()
+        {
+            return age;
+        }
+    }
+
+    @JsonIgnoreProperties({"foo", "bar"})
+    public static class IgnoringPropertiesPojo
+    {
+        int code;
+
+        @JsonIgnore
+        public String internal;
+
+        public String external;
+
+        @JsonIgnore
+        public void setCode(int c)
+        {
+            code = c;
+        }
+
+        public int getCode()
+        {
+            return code;
+        }
+    }
+
+    public static class ChangingPropertyNamesPojo
+    {
+        String name;
+
+        @JsonProperty("name")
+        public String getTheName()
+        {
+            return name;
+        }
+
+        public void setTheName(String n)
+        {
+            name = n;
+        }
+    }
+
+    protected interface FileSetup
+    {
+        void setup(File f)
+                throws Exception;
+    }
+
+    protected File createTempFile()
+            throws Exception
+    {
+        return createTempFile(null);
+    }
+
+    protected File createTempFile(FileSetup fileSetup)
+            throws Exception
+    {
+        File tempFile = File.createTempFile("test", "msgpack");
+        tempFile.deleteOnExit();
+        if (fileSetup != null) {
+            fileSetup.setup(tempFile);
+        }
+        return tempFile;
+    }
+
+    protected OutputStream createTempFileOutputStream()
+            throws IOException
+    {
+        File tempFile = File.createTempFile("test", "msgpack");
+        tempFile.deleteOnExit();
+        return new FileOutputStream(tempFile);
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackFactoryTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackFactoryTest.java
@@ -1,0 +1,198 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonEncoding;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.TSFBuilder;
+import tools.jackson.core.TokenStreamFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.msgpack.core.MessagePack;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessagePackFactoryTest
+        extends MessagePackDataformatTestBase
+{
+    @Test
+    public void testCreateGenerator()
+            throws IOException
+    {
+        JsonEncoding enc = JsonEncoding.UTF8;
+        JsonGenerator generator = factory.createGenerator(out, enc);
+        assertEquals(MessagePackGenerator.class, generator.getClass());
+    }
+
+    @Test
+    public void testCreateParser()
+            throws IOException
+    {
+        JsonParser parser = factory.createParser(in);
+        assertEquals(MessagePackParser.class, parser.getClass());
+    }
+
+    @Test
+    public void testCopyWithDefaultConfig()
+            throws IOException
+    {
+        MessagePackFactory messagePackFactory = new MessagePackFactory();
+        ObjectMapper objectMapper = new MessagePackMapper(messagePackFactory);
+
+        // Use the original ObjectMapper in advance
+        {
+            byte[] bytes = objectMapper.writeValueAsBytes(1234);
+            assertThat(objectMapper.readValue(bytes, Integer.class), is(1234));
+        }
+
+        // Copy the factory
+        TokenStreamFactory copiedFactory = messagePackFactory.copy();
+        assertThat(copiedFactory, is(instanceOf(MessagePackFactory.class)));
+        MessagePackFactory copiedMessagePackFactory = (MessagePackFactory) copiedFactory;
+
+        assertThat(copiedMessagePackFactory.getPackerConfig().isStr8FormatSupport(), is(true));
+        assertThat(copiedMessagePackFactory.getExtTypeCustomDesers(), is(nullValue()));
+
+        // Check the copied factory works fine
+        ObjectMapper copiedObjectMapper = new MessagePackMapper(copiedMessagePackFactory);
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        Map<String, Integer> deserialized = copiedObjectMapper
+            .readValue(objectMapper.writeValueAsBytes(map), new TypeReference<Map<String, Integer>>() {});
+        assertThat(deserialized.size(), is(1));
+        assertThat(deserialized.get("one"), is(1));
+    }
+
+    @Test
+    public void testRebuildWithDefaultConfig()
+            throws IOException
+    {
+        MessagePackFactory messagePackFactory = new MessagePackFactory();
+        TSFBuilder<?, ?> builder = messagePackFactory.rebuild();
+        assertThat(builder, is(instanceOf(MessagePackFactoryBuilder.class)));
+
+        MessagePackFactory rebuilt = (MessagePackFactory) builder.build();
+        assertThat(rebuilt, is(not(sameInstance(messagePackFactory))));
+        assertThat(rebuilt.getPackerConfig().isStr8FormatSupport(), is(true));
+        assertThat(rebuilt.getExtTypeCustomDesers(), is(nullValue()));
+
+        ObjectMapper rebuiltObjectMapper = new MessagePackMapper(rebuilt);
+        byte[] bytes = rebuiltObjectMapper.writeValueAsBytes(42);
+        assertThat(rebuiltObjectMapper.readValue(bytes, Integer.class), is(42));
+    }
+
+    @Test
+    public void testRebuildWithAdvancedConfig()
+            throws IOException
+    {
+        ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+        extTypeCustomDesers.addCustomDeser((byte) 42,
+                new ExtensionTypeCustomDeserializers.Deser()
+                {
+                    @Override
+                    public Object deserialize(byte[] data)
+                            throws IOException
+                    {
+                        TinyPojo pojo = new TinyPojo();
+                        pojo.t = new String(data);
+                        return pojo;
+                    }
+                }
+        );
+        MessagePack.PackerConfig packerConfig = new MessagePack.PackerConfig().withStr8FormatSupport(false);
+        MessagePackFactory messagePackFactory = new MessagePackFactory(packerConfig);
+        messagePackFactory.setExtTypeCustomDesers(extTypeCustomDesers);
+
+        MessagePackFactory rebuilt = (MessagePackFactory) messagePackFactory.rebuild().build();
+        assertThat(rebuilt, is(not(sameInstance(messagePackFactory))));
+        assertThat(rebuilt.getPackerConfig().isStr8FormatSupport(), is(false));
+        assertThat(rebuilt.getExtTypeCustomDesers().getDeser((byte) 42), is(notNullValue()));
+        assertThat(rebuilt.getExtTypeCustomDesers().getDeser((byte) 43), is(nullValue()));
+    }
+
+    @Test
+    public void testSnapshotReturnsNewInstance()
+    {
+        MessagePackFactory messagePackFactory = new MessagePackFactory();
+        TokenStreamFactory snapshot = messagePackFactory.snapshot();
+        assertThat(snapshot, is(not(sameInstance(messagePackFactory))));
+        assertThat(snapshot, is(instanceOf(MessagePackFactory.class)));
+    }
+
+    @Test
+    public void testCopyWithAdvancedConfig()
+            throws IOException
+    {
+        ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+        extTypeCustomDesers.addCustomDeser((byte) 42,
+                new ExtensionTypeCustomDeserializers.Deser()
+                {
+                    @Override
+                    public Object deserialize(byte[] data)
+                            throws IOException
+                    {
+                        TinyPojo pojo = new TinyPojo();
+                        pojo.t = new String(data);
+                        return pojo;
+                    }
+                }
+        );
+
+        MessagePack.PackerConfig msgpackPackerConfig = new MessagePack.PackerConfig().withStr8FormatSupport(false);
+
+        MessagePackFactory messagePackFactory = new MessagePackFactory(msgpackPackerConfig);
+        messagePackFactory.setExtTypeCustomDesers(extTypeCustomDesers);
+
+        ObjectMapper objectMapper = new MessagePackMapper(messagePackFactory);
+
+        // Use the original ObjectMapper in advance
+        {
+            byte[] bytes = objectMapper.writeValueAsBytes(1234);
+            assertThat(objectMapper.readValue(bytes, Integer.class), is(1234));
+        }
+
+        // Copy the factory
+        TokenStreamFactory copiedFactory = messagePackFactory.copy();
+        assertThat(copiedFactory, is(instanceOf(MessagePackFactory.class)));
+        MessagePackFactory copiedMessagePackFactory = (MessagePackFactory) copiedFactory;
+
+        assertThat(copiedMessagePackFactory.getPackerConfig().isStr8FormatSupport(), is(false));
+        assertThat(copiedMessagePackFactory.getExtTypeCustomDesers().getDeser((byte) 42), is(notNullValue()));
+        assertThat(copiedMessagePackFactory.getExtTypeCustomDesers().getDeser((byte) 43), is(nullValue()));
+
+        // Check the copied factory works fine
+        ObjectMapper copiedObjectMapper = new MessagePackMapper(copiedMessagePackFactory);
+        Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+        Map<String, Integer> deserialized = copiedObjectMapper
+            .readValue(objectMapper.writeValueAsBytes(map), new TypeReference<Map<String, Integer>>() {});
+        assertThat(deserialized.size(), is(1));
+        assertThat(deserialized.get("one"), is(1));
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackGeneratorTest.java
@@ -1,0 +1,1446 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.JsonEncoding;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.databind.module.SimpleModule;
+import org.junit.Test;
+import org.msgpack.core.ExtensionTypeHeader;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessageUnpacker;
+import org.msgpack.core.buffer.ArrayBufferInput;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MessagePackGeneratorTest
+        extends MessagePackDataformatTestBase
+{
+    @Test
+    public void testGeneratorShouldWriteObject()
+            throws IOException
+    {
+        Map<String, Object> hashMap = new HashMap<String, Object>();
+        // #1
+        hashMap.put("str", "komamitsu");
+        // #2
+        hashMap.put("boolean", true);
+        // #3
+        hashMap.put("int", Integer.MAX_VALUE);
+        // #4
+        hashMap.put("long", Long.MIN_VALUE);
+        // #5
+        hashMap.put("float", 3.14159f);
+        // #6
+        hashMap.put("double", 3.14159d);
+        // #7
+        hashMap.put("bin", new byte[] {0x00, 0x01, (byte) 0xFE, (byte) 0xFF});
+        // #8
+        Map<String, Object> childObj = new HashMap<String, Object>();
+        childObj.put("co_str", "child#0");
+        childObj.put("co_int", 12345);
+        hashMap.put("childObj", childObj);
+        // #9
+        List<Object> childArray = new ArrayList<Object>();
+        childArray.add("child#1");
+        childArray.add(1.23f);
+        hashMap.put("childArray", childArray);
+        // #10
+        byte[] hello = "hello".getBytes("UTF-8");
+        hashMap.put("ext", new MessagePackExtensionType((byte) 17, hello));
+
+        long bitmap = 0;
+        byte[] bytes = objectMapper.writeValueAsBytes(hashMap);
+        MessageUnpacker messageUnpacker = MessagePack.newDefaultUnpacker(new ArrayBufferInput(bytes));
+        assertEquals(hashMap.size(), messageUnpacker.unpackMapHeader());
+        for (int i = 0; i < hashMap.size(); i++) {
+            String key = messageUnpacker.unpackString();
+            if (key.equals("str")) {
+                // #1
+                assertEquals("komamitsu", messageUnpacker.unpackString());
+                bitmap |= 0x1 << 0;
+            }
+            else if (key.equals("boolean")) {
+                // #2
+                assertTrue(messageUnpacker.unpackBoolean());
+                bitmap |= 0x1 << 1;
+            }
+            else if (key.equals("int")) {
+                // #3
+                assertEquals(Integer.MAX_VALUE, messageUnpacker.unpackInt());
+                bitmap |= 0x1 << 2;
+            }
+            else if (key.equals("long")) {
+                // #4
+                assertEquals(Long.MIN_VALUE, messageUnpacker.unpackLong());
+                bitmap |= 0x1 << 3;
+            }
+            else if (key.equals("float")) {
+                // #5
+                assertEquals(3.14159f, messageUnpacker.unpackFloat(), 0.01f);
+                bitmap |= 0x1 << 4;
+            }
+            else if (key.equals("double")) {
+                // #6
+                assertEquals(3.14159d, messageUnpacker.unpackDouble(), 0.01f);
+                bitmap |= 0x1 << 5;
+            }
+            else if (key.equals("bin")) {
+                // #7
+                assertEquals(4, messageUnpacker.unpackBinaryHeader());
+                assertEquals((byte) 0x00, messageUnpacker.unpackByte());
+                assertEquals((byte) 0x01, messageUnpacker.unpackByte());
+                assertEquals((byte) 0xFE, messageUnpacker.unpackByte());
+                assertEquals((byte) 0xFF, messageUnpacker.unpackByte());
+                bitmap |= 0x1 << 6;
+            }
+            else if (key.equals("childObj")) {
+                // #8
+                assertEquals(2, messageUnpacker.unpackMapHeader());
+                for (int j = 0; j < 2; j++) {
+                    String childKey = messageUnpacker.unpackString();
+                    if (childKey.equals("co_str")) {
+                        assertEquals("child#0", messageUnpacker.unpackString());
+                        bitmap |= 0x1 << 7;
+                    }
+                    else if (childKey.equals("co_int")) {
+                        assertEquals(12345, messageUnpacker.unpackInt());
+                        bitmap |= 0x1 << 8;
+                    }
+                    else {
+                        assertTrue(false);
+                    }
+                }
+            }
+            else if (key.equals("childArray")) {
+                // #9
+                assertEquals(2, messageUnpacker.unpackArrayHeader());
+                assertEquals("child#1", messageUnpacker.unpackString());
+                assertEquals(1.23f, messageUnpacker.unpackFloat(), 0.01f);
+                bitmap |= 0x1 << 9;
+            }
+            else if (key.equals("ext")) {
+                // #10
+                ExtensionTypeHeader header = messageUnpacker.unpackExtensionTypeHeader();
+                assertEquals(17, header.getType());
+                assertEquals(5, header.getLength());
+                ByteBuffer payload = ByteBuffer.allocate(header.getLength());
+                payload.flip();
+                payload.limit(payload.capacity());
+                messageUnpacker.readPayload(payload);
+                payload.flip();
+                assertArrayEquals("hello".getBytes(), payload.array());
+                bitmap |= 0x1 << 10;
+            }
+            else {
+                assertTrue(false);
+            }
+        }
+        assertEquals(0x07FF, bitmap);
+    }
+
+    @Test
+    public void testGeneratorShouldWriteArray()
+            throws IOException
+    {
+        List<Object> array = new ArrayList<Object>();
+        // #1
+        array.add("komamitsu");
+        // #2
+        array.add(Integer.MAX_VALUE);
+        // #3
+        array.add(Long.MIN_VALUE);
+        // #4
+        array.add(3.14159f);
+        // #5
+        array.add(3.14159d);
+        // #6
+        Map<String, Object> childObject = new HashMap<String, Object>();
+        childObject.put("str", "foobar");
+        childObject.put("num", 123456);
+        array.add(childObject);
+        // #7
+        array.add(false);
+
+        long bitmap = 0;
+        byte[] bytes = objectMapper.writeValueAsBytes(array);
+        MessageUnpacker messageUnpacker = MessagePack.newDefaultUnpacker(new ArrayBufferInput(bytes));
+        assertEquals(array.size(), messageUnpacker.unpackArrayHeader());
+        // #1
+        assertEquals("komamitsu", messageUnpacker.unpackString());
+        // #2
+        assertEquals(Integer.MAX_VALUE, messageUnpacker.unpackInt());
+        // #3
+        assertEquals(Long.MIN_VALUE, messageUnpacker.unpackLong());
+        // #4
+        assertEquals(3.14159f, messageUnpacker.unpackFloat(), 0.01f);
+        // #5
+        assertEquals(3.14159d, messageUnpacker.unpackDouble(), 0.01f);
+        // #6
+        assertEquals(2, messageUnpacker.unpackMapHeader());
+        for (int i = 0; i < childObject.size(); i++) {
+            String key = messageUnpacker.unpackString();
+            if (key.equals("str")) {
+                assertEquals("foobar", messageUnpacker.unpackString());
+                bitmap |= 0x1 << 0;
+            }
+            else if (key.equals("num")) {
+                assertEquals(123456, messageUnpacker.unpackInt());
+                bitmap |= 0x1 << 1;
+            }
+            else {
+                assertTrue(false);
+            }
+        }
+        assertEquals(0x3, bitmap);
+        // #7
+        assertEquals(false, messageUnpacker.unpackBoolean());
+    }
+
+    @Test
+    public void testMessagePackGeneratorDirectly()
+            throws Exception
+    {
+        MessagePackFactory messagePackFactory = new MessagePackFactory();
+        File tempFile = createTempFile();
+
+        JsonGenerator generator = messagePackFactory.createGenerator(ObjectWriteContext.empty(), tempFile, JsonEncoding.UTF8);
+        assertTrue(generator instanceof MessagePackGenerator);
+        generator.writeStartArray();
+        generator.writeNumber(0);
+        generator.writeString("one");
+        generator.writeNumber(2.0f);
+        generator.writeEndArray();
+        generator.flush();
+        generator.flush();      // intentional
+        generator.close();
+
+        FileInputStream fileInputStream = new FileInputStream(tempFile);
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(fileInputStream);
+        assertEquals(3, unpacker.unpackArrayHeader());
+        assertEquals(0, unpacker.unpackInt());
+        assertEquals("one", unpacker.unpackString());
+        assertEquals(2.0f, unpacker.unpackFloat(), 0.001f);
+        assertFalse(unpacker.hasNext());
+    }
+
+    @Test
+    public void testWritePrimitives()
+            throws Exception
+    {
+        MessagePackFactory messagePackFactory = new MessagePackFactory();
+        File tempFile = createTempFile();
+
+        JsonGenerator generator = messagePackFactory.createGenerator(ObjectWriteContext.empty(), tempFile, JsonEncoding.UTF8);
+        assertTrue(generator instanceof MessagePackGenerator);
+        generator.writeNumber(0);
+        generator.writeString("one");
+        generator.writeNumber(2.0f);
+        generator.writeString("三");
+        generator.writeString("444④");
+        generator.flush();
+        generator.close();
+
+        FileInputStream fileInputStream = new FileInputStream(tempFile);
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(fileInputStream);
+        assertEquals(0, unpacker.unpackInt());
+        assertEquals("one", unpacker.unpackString());
+        assertEquals(2.0f, unpacker.unpackFloat(), 0.001f);
+        assertEquals("三", unpacker.unpackString());
+        assertEquals("444④", unpacker.unpackString());
+        assertFalse(unpacker.hasNext());
+    }
+
+    @Test
+    public void testBigDecimal()
+            throws IOException
+    {
+        ObjectMapper mapper = new MessagePackMapper(new MessagePackFactory());
+
+        {
+            double d0 = 1.23456789;
+            double d1 = 1.23450000000000000000006789;
+            String d2 = "12.30";
+            String d3 = "0.00001";
+            List<BigDecimal> bigDecimals = Arrays.asList(
+                    BigDecimal.valueOf(d0),
+                    BigDecimal.valueOf(d1),
+                    new BigDecimal(d2),
+                    new BigDecimal(d3),
+                    BigDecimal.valueOf(Double.MIN_VALUE),
+                    BigDecimal.valueOf(Double.MAX_VALUE),
+                    BigDecimal.valueOf(Double.MIN_NORMAL)
+            );
+
+            byte[] bytes = mapper.writeValueAsBytes(bigDecimals);
+            MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes);
+
+            assertEquals(bigDecimals.size(), unpacker.unpackArrayHeader());
+            assertEquals(d0, unpacker.unpackDouble(), 0.000000000000001);
+            assertEquals(d1, unpacker.unpackDouble(), 0.000000000000001);
+            assertEquals(Double.valueOf(d2), unpacker.unpackDouble(), 0.000000000000001);
+            assertEquals(Double.valueOf(d3), unpacker.unpackDouble(), 0.000000000000001);
+            assertEquals(Double.MIN_VALUE, unpacker.unpackDouble(), 0.000000000000001);
+            assertEquals(Double.MAX_VALUE, unpacker.unpackDouble(), 0.000000000000001);
+            assertEquals(Double.MIN_NORMAL, unpacker.unpackDouble(), 0.000000000000001);
+        }
+
+        {
+            BigDecimal decimal = new BigDecimal("1234.567890123456789012345678901234567890");
+            List<BigDecimal> bigDecimals = Arrays.asList(
+                    decimal
+            );
+
+            try {
+                mapper.writeValueAsBytes(bigDecimals);
+                assertTrue(false);
+            }
+            catch (IllegalArgumentException e) {
+                assertTrue(true);
+            }
+        }
+    }
+
+    @Test
+    public void testBigDecimalCompareTo()
+            throws IOException
+    {
+        ObjectMapper mapper = new MessagePackMapper(new MessagePackFactory());
+
+        // BigDecimal with trailing zeros is representable as double — must not throw
+        BigDecimal trailingZeros = new BigDecimal("1.50");
+        byte[] bytes = mapper.writeValueAsBytes(trailingZeros);
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes);
+        assertEquals(1.5, unpacker.unpackDouble(), 0.0);
+
+        // BigDecimal with precision beyond double range must throw
+        BigDecimal tooHighPrecision = new BigDecimal("1.00000000000000000000000000000000000001");
+        try {
+            mapper.writeValueAsBytes(tooHighPrecision);
+            assertTrue(false);
+        }
+        catch (IllegalArgumentException e) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testEnableFeatureAutoCloseTarget()
+            throws IOException
+    {
+        OutputStream out = createTempFileOutputStream();
+        ObjectMapper objectMapper = new MessagePackMapper(new MessagePackFactory());
+        List<Integer> integers = Arrays.asList(1);
+        objectMapper.writeValue(out, integers);
+        assertThrows(JacksonException.class, () -> {
+            objectMapper.writeValue(out, integers);
+        });
+    }
+
+    @Test
+    public void testDisableFeatureAutoCloseTarget()
+            throws Exception
+    {
+        File tempFile = createTempFile();
+        OutputStream out = new FileOutputStream(tempFile);
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                .build();
+        List<Integer> integers = Arrays.asList(1);
+        objectMapper.writeValue(out, integers);
+        objectMapper.writeValue(out, integers);
+        out.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(new FileInputStream(tempFile));
+        assertEquals(1, unpacker.unpackArrayHeader());
+        assertEquals(1, unpacker.unpackInt());
+        assertEquals(1, unpacker.unpackArrayHeader());
+        assertEquals(1, unpacker.unpackInt());
+    }
+
+    @Test
+    public void testWritePrimitiveObjectViaObjectMapper()
+            throws Exception
+    {
+        File tempFile = createTempFile();
+        try (OutputStream out = Files.newOutputStream(tempFile.toPath())) {
+            ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                    .build();
+            objectMapper.writeValue(out, 1);
+            objectMapper.writeValue(out, "two");
+            objectMapper.writeValue(out, 3.14);
+            objectMapper.writeValue(out, Arrays.asList(4));
+            objectMapper.writeValue(out, 5L);
+        }
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(new FileInputStream(tempFile))) {
+            assertEquals(1, unpacker.unpackInt());
+            assertEquals("two", unpacker.unpackString());
+            assertEquals(3.14, unpacker.unpackFloat(), 0.0001);
+            assertEquals(1, unpacker.unpackArrayHeader());
+            assertEquals(4, unpacker.unpackInt());
+            assertEquals(5, unpacker.unpackLong());
+        }
+    }
+
+    @Test
+    public void testInMultiThreads()
+            throws Exception
+    {
+        int threadCount = 8;
+        final int loopCount = 4000;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                .build();
+        final List<ByteArrayOutputStream> buffers = new ArrayList<ByteArrayOutputStream>(threadCount);
+        List<Future<Exception>> results = new ArrayList<Future<Exception>>();
+
+        for (int ti = 0; ti < threadCount; ti++) {
+            buffers.add(new ByteArrayOutputStream());
+            final int threadIndex = ti;
+            results.add(executorService.submit(new Callable<Exception>()
+            {
+                @Override
+                public Exception call()
+                        throws Exception
+                {
+                    try {
+                        for (int i = 0; i < loopCount; i++) {
+                            objectMapper.writeValue(buffers.get(threadIndex), threadIndex);
+                        }
+                        return null;
+                    }
+                    catch (Exception e) {
+                        return e;
+                    }
+                }
+            }));
+        }
+
+        for (int ti = 0; ti < threadCount; ti++) {
+            Future<Exception> exceptionFuture = results.get(ti);
+            Exception exception = exceptionFuture.get(20, TimeUnit.SECONDS);
+            if (exception != null) {
+                throw exception;
+            }
+            else {
+                try (ByteArrayOutputStream outputStream = buffers.get(ti);
+                MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(outputStream.toByteArray())) {
+                    for (int i = 0; i < loopCount; i++) {
+                        assertEquals(ti, unpacker.unpackInt());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDisableStr8Support()
+      throws Exception
+    {
+        String str8LengthString = new String(new char[32]).replace("\0", "a");
+
+        ObjectMapper defaultMapper = new MessagePackMapper(new MessagePackFactory());
+        byte[] resultWithStr8Format = defaultMapper.writeValueAsBytes(str8LengthString);
+        assertEquals(resultWithStr8Format[0], MessagePack.Code.STR8);
+
+        MessagePack.PackerConfig config = new MessagePack.PackerConfig().withStr8FormatSupport(false);
+        ObjectMapper mapperWithConfig = new MessagePackMapper(new MessagePackFactory(config));
+        byte[] resultWithoutStr8Format = mapperWithConfig.writeValueAsBytes(str8LengthString);
+        assertNotEquals(resultWithoutStr8Format[0], MessagePack.Code.STR8);
+    }
+
+    interface NonStringKeyMapHolder
+    {
+        Map<Integer, String> getIntMap();
+
+        void setIntMap(Map<Integer, String> intMap);
+
+        Map<Long, String> getLongMap();
+
+        void setLongMap(Map<Long, String> longMap);
+
+        Map<Float, String> getFloatMap();
+
+        void setFloatMap(Map<Float, String> floatMap);
+
+        Map<Double, String> getDoubleMap();
+
+        void setDoubleMap(Map<Double, String> doubleMap);
+
+        Map<BigInteger, String> getBigIntMap();
+
+        void setBigIntMap(Map<BigInteger, String> doubleMap);
+    }
+
+    public static class NonStringKeyMapHolderWithAnnotation
+            implements NonStringKeyMapHolder
+    {
+        @JsonSerialize(keyUsing = MessagePackKeySerializer.class)
+        private Map<Integer, String> intMap = new HashMap<Integer, String>();
+
+        @JsonSerialize(keyUsing = MessagePackKeySerializer.class)
+        private Map<Long, String> longMap = new HashMap<Long, String>();
+
+        @JsonSerialize(keyUsing = MessagePackKeySerializer.class)
+        private Map<Float, String> floatMap = new HashMap<Float, String>();
+
+        @JsonSerialize(keyUsing = MessagePackKeySerializer.class)
+        private Map<Double, String> doubleMap = new HashMap<Double, String>();
+
+        @JsonSerialize(keyUsing = MessagePackKeySerializer.class)
+        private Map<BigInteger, String> bigIntMap = new HashMap<BigInteger, String>();
+
+        @Override
+        public Map<Integer, String> getIntMap()
+        {
+            return intMap;
+        }
+
+        @Override
+        public void setIntMap(Map<Integer, String> intMap)
+        {
+            this.intMap = intMap;
+        }
+
+        @Override
+        public Map<Long, String> getLongMap()
+        {
+            return longMap;
+        }
+
+        @Override
+        public void setLongMap(Map<Long, String> longMap)
+        {
+            this.longMap = longMap;
+        }
+
+        @Override
+        public Map<Float, String> getFloatMap()
+        {
+            return floatMap;
+        }
+
+        @Override
+        public void setFloatMap(Map<Float, String> floatMap)
+        {
+            this.floatMap = floatMap;
+        }
+
+        @Override
+        public Map<Double, String> getDoubleMap()
+        {
+            return doubleMap;
+        }
+
+        @Override
+        public void setDoubleMap(Map<Double, String> doubleMap)
+        {
+            this.doubleMap = doubleMap;
+        }
+
+        @Override
+        public Map<BigInteger, String> getBigIntMap()
+        {
+            return bigIntMap;
+        }
+
+        @Override
+        public void setBigIntMap(Map<BigInteger, String> bigIntMap)
+        {
+            this.bigIntMap = bigIntMap;
+        }
+    }
+
+    public static class NonStringKeyMapHolderWithoutAnnotation
+            implements NonStringKeyMapHolder
+    {
+        private Map<Integer, String> intMap = new HashMap<Integer, String>();
+
+        private Map<Long, String> longMap = new HashMap<Long, String>();
+
+        private Map<Float, String> floatMap = new HashMap<Float, String>();
+
+        private Map<Double, String> doubleMap = new HashMap<Double, String>();
+
+        private Map<BigInteger, String> bigIntMap = new HashMap<BigInteger, String>();
+
+        @Override
+        public Map<Integer, String> getIntMap()
+        {
+            return intMap;
+        }
+
+        @Override
+        public void setIntMap(Map<Integer, String> intMap)
+        {
+            this.intMap = intMap;
+        }
+
+        @Override
+        public Map<Long, String> getLongMap()
+        {
+            return longMap;
+        }
+
+        @Override
+        public void setLongMap(Map<Long, String> longMap)
+        {
+            this.longMap = longMap;
+        }
+
+        @Override
+        public Map<Float, String> getFloatMap()
+        {
+            return floatMap;
+        }
+
+        @Override
+        public void setFloatMap(Map<Float, String> floatMap)
+        {
+            this.floatMap = floatMap;
+        }
+
+        @Override
+        public Map<Double, String> getDoubleMap()
+        {
+            return doubleMap;
+        }
+
+        @Override
+        public void setDoubleMap(Map<Double, String> doubleMap)
+        {
+            this.doubleMap = doubleMap;
+        }
+
+        @Override
+        public Map<BigInteger, String> getBigIntMap()
+        {
+            return bigIntMap;
+        }
+
+        @Override
+        public void setBigIntMap(Map<BigInteger, String> bigIntMap)
+        {
+            this.bigIntMap = bigIntMap;
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNonStringKey()
+            throws Exception
+    {
+        for (Class<? extends NonStringKeyMapHolder> clazz :
+                Arrays.asList(
+                        NonStringKeyMapHolderWithAnnotation.class,
+                        NonStringKeyMapHolderWithoutAnnotation.class)) {
+            NonStringKeyMapHolder mapHolder = clazz.getConstructor().newInstance();
+            mapHolder.getIntMap().put(Integer.MAX_VALUE, "i");
+            mapHolder.getLongMap().put(Long.MIN_VALUE, "l");
+            mapHolder.getFloatMap().put(Float.MAX_VALUE, "f");
+            mapHolder.getDoubleMap().put(Double.MIN_VALUE, "d");
+            mapHolder.getBigIntMap().put(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), "bi");
+
+            ObjectMapper objectMapper;
+            if (mapHolder instanceof NonStringKeyMapHolderWithoutAnnotation) {
+                SimpleModule mod = new SimpleModule("test");
+                mod.addKeySerializer(Object.class, new MessagePackKeySerializer());
+                objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                        .addModule(mod)
+                        .build();
+            }
+            else {
+                objectMapper = new MessagePackMapper(new MessagePackFactory());
+            }
+
+            byte[] bytes = objectMapper.writeValueAsBytes(mapHolder);
+            MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes);
+            assertEquals(5, unpacker.unpackMapHeader());
+            for (int i = 0; i < 5; i++) {
+                String keyName = unpacker.unpackString();
+                assertThat(unpacker.unpackMapHeader(), is(1));
+                if (keyName.equals("intMap")) {
+                    assertThat(unpacker.unpackInt(), is(Integer.MAX_VALUE));
+                    assertThat(unpacker.unpackString(), is("i"));
+                }
+                else if (keyName.equals("longMap")) {
+                    assertThat(unpacker.unpackLong(), is(Long.MIN_VALUE));
+                    assertThat(unpacker.unpackString(), is("l"));
+                }
+                else if (keyName.equals("floatMap")) {
+                    assertThat(unpacker.unpackFloat(), is(Float.MAX_VALUE));
+                    assertThat(unpacker.unpackString(), is("f"));
+                }
+                else if (keyName.equals("doubleMap")) {
+                    assertThat(unpacker.unpackDouble(), is(Double.MIN_VALUE));
+                    assertThat(unpacker.unpackString(), is("d"));
+                }
+                else if (keyName.equals("bigIntMap")) {
+                    assertThat(unpacker.unpackBigInteger(), is(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE)));
+                    assertThat(unpacker.unpackString(), is("bi"));
+                }
+                else {
+                    fail("Unexpected key name: " + keyName);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testComplexTypeKey()
+            throws IOException
+    {
+        HashMap<TinyPojo, Integer> map = new HashMap<TinyPojo, Integer>();
+        TinyPojo pojo = new TinyPojo();
+        pojo.t = "foo";
+        map.put(pojo, 42);
+
+        SimpleModule mod = new SimpleModule("test");
+        mod.addKeySerializer(TinyPojo.class, new MessagePackKeySerializer());
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(mod)
+                .build();
+        byte[] bytes = objectMapper.writeValueAsBytes(map);
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes);
+        assertThat(unpacker.unpackMapHeader(), is(1));
+        assertThat(unpacker.unpackMapHeader(), is(1));
+        assertThat(unpacker.unpackString(), is("t"));
+        assertThat(unpacker.unpackString(), is("foo"));
+        assertThat(unpacker.unpackInt(), is(42));
+    }
+
+    @Test
+    public void testComplexTypeKeyWithV06Format()
+            throws IOException
+    {
+        HashMap<TinyPojo, Integer> map = new HashMap<TinyPojo, Integer>();
+        TinyPojo pojo = new TinyPojo();
+        pojo.t = "foo";
+        map.put(pojo, 42);
+
+        SimpleModule mod = new SimpleModule("test");
+        mod.addKeySerializer(TinyPojo.class, new MessagePackKeySerializer());
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .annotationIntrospector(new JsonArrayFormat())
+                .addModule(mod)
+                .build();
+        byte[] bytes = objectMapper.writeValueAsBytes(map);
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes);
+        assertThat(unpacker.unpackMapHeader(), is(1));
+        assertThat(unpacker.unpackArrayHeader(), is(1));
+        assertThat(unpacker.unpackString(), is("foo"));
+        assertThat(unpacker.unpackInt(), is(42));
+    }
+
+    public static class IntegerSerializerStoringAsString
+            extends ValueSerializer<Integer>
+    {
+        @Override
+        public void serialize(Integer value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeNumber(String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void serializeStringAsInteger()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule().addSerializer(Integer.class, new IntegerSerializerStoringAsString()))
+                .build();
+
+        assertThat(
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(Integer.MAX_VALUE)).unpackInt(),
+                is(Integer.MAX_VALUE));
+    }
+
+    public static class LongSerializerStoringAsString
+            extends ValueSerializer<Long>
+    {
+        @Override
+        public void serialize(Long value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeNumber(String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void serializeStringAsLong()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule().addSerializer(Long.class, new LongSerializerStoringAsString()))
+                .build();
+
+        assertThat(
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(Long.MIN_VALUE)).unpackLong(),
+                is(Long.MIN_VALUE));
+    }
+
+    public static class FloatSerializerStoringAsString
+            extends ValueSerializer<Float>
+    {
+        @Override
+        public void serialize(Float value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeNumber(String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void serializeStringAsFloat()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule().addSerializer(Float.class, new FloatSerializerStoringAsString()))
+                .build();
+
+        assertThat(
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(Float.MAX_VALUE)).unpackFloat(),
+                is(Float.MAX_VALUE));
+    }
+
+    public static class DoubleSerializerStoringAsString
+            extends ValueSerializer<Double>
+    {
+        @Override
+        public void serialize(Double value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeNumber(String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void serializeStringAsDouble()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule().addSerializer(Double.class, new DoubleSerializerStoringAsString()))
+                .build();
+
+        assertThat(
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(Double.MIN_VALUE)).unpackDouble(),
+                is(Double.MIN_VALUE));
+    }
+
+   public static class BigDecimalSerializerStoringAsString
+            extends ValueSerializer<BigDecimal>
+    {
+        @Override
+        public void serialize(BigDecimal value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeNumber(String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void serializeStringAsBigDecimal()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule().addSerializer(BigDecimal.class, new BigDecimalSerializerStoringAsString()))
+                .build();
+
+        BigDecimal bd = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+        assertThat(
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(bd)).unpackBigInteger(),
+                is(bd.toBigIntegerExact()));
+    }
+
+    public static class BigIntegerSerializerStoringAsString
+            extends ValueSerializer<BigInteger>
+    {
+        @Override
+        public void serialize(BigInteger value, JsonGenerator gen, SerializationContext serializers)
+                throws JacksonException
+        {
+            gen.writeNumber(String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void serializeStringAsBigInteger()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule().addSerializer(BigInteger.class, new BigIntegerSerializerStoringAsString()))
+                .build();
+
+        BigInteger bi = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertThat(
+            MessagePack.newDefaultUnpacker(objectMapper.writeValueAsBytes(bi)).unpackBigInteger(),
+                is(bi));
+    }
+
+    @Test
+    public void testNestedSerialization() throws Exception
+    {
+        ObjectMapper objectMapper = new MessagePackMapper(
+                new MessagePackFactory().setReuseResourceInGenerator(false));
+        OuterClass outerClass = objectMapper.readValue(
+                objectMapper.writeValueAsBytes(new OuterClass("Foo")),
+                OuterClass.class);
+        assertEquals("Foo", outerClass.getName());
+    }
+
+    static class OuterClass
+    {
+        private final String name;
+
+        public OuterClass(@JsonProperty("name") String name)
+        {
+            this.name = name;
+        }
+
+        public String getName()
+        {
+            ObjectMapper objectMapper = new MessagePackMapper(new MessagePackFactory());
+            InnerClass innerClass = objectMapper.readValue(
+                    objectMapper.writeValueAsBytes(new InnerClass("Bar")),
+                    InnerClass.class);
+            assertEquals("Bar", innerClass.getName());
+
+            return name;
+        }
+    }
+
+    static class InnerClass
+    {
+        private final String name;
+
+        public InnerClass(@JsonProperty("name") String name)
+        {
+            this.name = name;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+    }
+
+    @Test
+    public void testIsClosedAfterClose()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        assertFalse(generator.isClosed());
+        generator.writeStartArray();
+        generator.writeEndArray();
+        generator.close();
+        assertTrue(generator.isClosed());
+    }
+
+    @Test
+    public void testGeneratorReusableAfterRootContainerClose()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeNumber(1);
+        generator.writeEndArray();
+        generator.flush();
+
+        // Write a second root value; currentState must have reset to IN_ROOT
+        generator.writeStartObject();
+        generator.writeName("k");
+        generator.writeNumber(2);
+        generator.writeEndObject();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        assertEquals(1, unpacker.unpackArrayHeader());
+        assertEquals(1, unpacker.unpackInt());
+        assertEquals(1, unpacker.unpackMapHeader());
+        assertEquals("k", unpacker.unpackString());
+        assertEquals(2, unpacker.unpackInt());
+    }
+
+    @Test
+    public void testWriteRawStringWithOffset()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeRaw("XXhelloXX", 2, 5); // "hello"
+        generator.writeEndArray();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        unpacker.unpackArrayHeader();
+        assertEquals("hello", unpacker.unpackString());
+    }
+
+    @Test
+    public void testWriteStringCharArrayWithOffset()
+            throws IOException
+    {
+        // Padding chars before/after the actual content to test non-zero offset
+        char[] buf = new char[] {'X', 'X', 'h', 'e', 'l', 'l', 'o', 'X'};
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeString(buf, 2, 5); // "hello"
+        generator.writeEndArray();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        unpacker.unpackArrayHeader();
+        assertEquals("hello", unpacker.unpackString());
+    }
+
+    @Test
+    public void testWriteStringCharArrayWithOffsetNonAscii()
+            throws IOException
+    {
+        // Non-ASCII to exercise the non-fast-path in getBytesIfAscii
+        char[] buf = new char[] {'X', '三', '四', '五', 'X'}; // 三四五
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeString(buf, 1, 3);
+        generator.writeEndArray();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        unpacker.unpackArrayHeader();
+        assertEquals("三四五", unpacker.unpackString());
+    }
+
+    @Test
+    public void testWriteUTF8StringWithOffset()
+            throws IOException
+    {
+        // Padding bytes before/after to test non-zero offset in writeUTF8String
+        byte[] buf = new byte[] {'X', 'X', 'h', 'i', 'X'};
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeUTF8String(buf, 2, 2); // "hi"
+        generator.writeEndArray();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        unpacker.unpackArrayHeader();
+        assertEquals("hi", unpacker.unpackString());
+    }
+
+    @Test
+    public void testWriteBinaryWithOffset()
+            throws IOException
+    {
+        byte[] data = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04};
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeBinary(data, 1, 3); // bytes 0x01, 0x02, 0x03
+        generator.writeEndArray();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        unpacker.unpackArrayHeader();
+        byte[] result = unpacker.readPayload(unpacker.unpackBinaryHeader());
+        assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, result);
+    }
+
+    @Test
+    public void testWriteBinaryByteBufferWithOffset()
+            throws IOException
+    {
+        byte[] data = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04};
+        ByteBuffer bb = ByteBuffer.wrap(data, 1, 3); // position=1, limit=4, remaining=3
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        ObjectMapper mapper = new MessagePackMapper(factory);
+        mapper.writeValue(generator, bb);
+        generator.writeEndArray();
+        generator.close();
+
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(baos.toByteArray());
+        unpacker.unpackArrayHeader();
+        byte[] result = unpacker.readPayload(unpacker.unpackBinaryHeader());
+        assertArrayEquals(new byte[] {0x01, 0x02, 0x03}, result);
+    }
+
+    @Test
+    public void testStreamWriteContext()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+
+        TokenStreamContext ctx = generator.streamWriteContext();
+        assertNotEquals(null, ctx);
+        assertTrue(ctx.inRoot());
+
+        generator.writeStartArray();
+        ctx = generator.streamWriteContext();
+        assertTrue(ctx.inArray());
+
+        generator.writeStartObject();
+        ctx = generator.streamWriteContext();
+        assertTrue(ctx.inObject());
+
+        generator.writeName("k");
+        assertEquals("k", ctx.currentName());
+
+        generator.writeNumber(1);
+        generator.writeEndObject();
+        ctx = generator.streamWriteContext();
+        assertTrue(ctx.inArray());
+
+        generator.writeEndArray();
+        ctx = generator.streamWriteContext();
+        assertTrue(ctx.inRoot());
+
+        generator.close();
+    }
+
+    @Test
+    public void testCurrentValue()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+
+        Object pojo = new Object();
+        generator.writeStartObject(pojo);
+        assertEquals(pojo, generator.currentValue());
+        generator.writeName("k");
+        generator.writeNumber(1);
+        generator.writeEndObject();
+        generator.close();
+    }
+
+    @Test
+    public void testVersion()
+    {
+        assertNotEquals(null, factory.version());
+        assertEquals("org.msgpack", factory.version().getGroupId());
+        assertEquals("jackson-dataformat-msgpack-jackson3", factory.version().getArtifactId());
+    }
+
+    @Test
+    public void testSerializedStringMethods() throws IOException
+    {
+        MessagePackSerializedString s = new MessagePackSerializedString("hello");
+
+        byte[] utf8Target = new byte[10];
+        int written = s.appendUnquotedUTF8(utf8Target, 2);
+        assertEquals(5, written);
+        assertArrayEquals(new byte[] {'h', 'e', 'l', 'l', 'o'}, Arrays.copyOfRange(utf8Target, 2, 7));
+
+        char[] charTarget = new char[10];
+        written = s.appendUnquoted(charTarget, 3);
+        assertEquals(5, written);
+        assertEquals("hello", new String(charTarget, 3, 5));
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        written = s.writeUnquotedUTF8(baos);
+        assertEquals(5, written);
+        assertArrayEquals("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8), baos.toByteArray());
+    }
+
+    // Regression: addValueNode must call writeContext.writeValue() so that the Jackson write
+    // context resets _gotPropertyId after each value. Without it, the second writeName() in the
+    // same object finds _gotPropertyId still set from the first writeName() and returns false
+    // without updating currentName(), leaving streamWriteContext().currentName() stale.
+    @Test
+    public void testWriteContextCurrentNameIsUpdatedForEveryProperty()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartObject();
+
+        generator.writeName("alpha");
+        generator.writeNumber(1);
+
+        generator.writeName("beta");
+        assertEquals("beta", generator.streamWriteContext().currentName());
+        generator.writeNumber(2);
+
+        generator.writeEndObject();
+        generator.close();
+    }
+
+    // Regression: writePropertyId() must call writeContext.writeName() when supportIntegerKeys
+    // is true. Without it, streamWriteContext() never learns a name was written, so currentName()
+    // returns null and any downstream code relying on context state (e.g. duplicate-name
+    // detection, error messages) sees wrong state.
+    @Test
+    public void testWritePropertyIdUpdatesWriteContext()
+            throws IOException
+    {
+        MessagePackFactory intKeyFactory = new MessagePackFactory().setSupportIntegerKeys(true);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = intKeyFactory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartObject();
+        generator.writePropertyId(42L);
+        assertEquals("42", generator.streamWriteContext().currentName());
+        generator.writeString("value");
+        generator.writeEndObject();
+        generator.close();
+    }
+
+    @Test
+    public void testNullSerializedStringKeyDoesNotThrowNpe()
+            throws IOException
+    {
+        // writeName(MessagePackSerializedString(null)) calls getValue() → null.toString() → NPE.
+        // A null key should be serialized as msgpack nil, not crash.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = new MessagePackFactory().createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartObject();
+        generator.writeName(new MessagePackSerializedString(null));
+        generator.writeNumber(42);
+        generator.writeEndObject();
+        generator.close();
+
+        // Verify the null key round-trips as PROPERTY_NAME with null current name
+        try (JsonParser parser =
+                new MessagePackFactory().createParser(ObjectReadContext.empty(), baos.toByteArray())) {
+            assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, parser.nextToken());
+            assertNull(parser.currentName());
+            assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+            assertEquals(42, parser.getIntValue());
+            assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        }
+    }
+
+    @Test
+    public void testFlushMidWriteOnSecondRootContainerDoesNotCorruptState()
+            throws IOException
+    {
+        // After the first root container closes, isElementsClosed=true.
+        // Opening a second root container does not reset this flag, so a
+        // flush() call while the second container is still open will pack
+        // the incomplete node tree and wipe nodes[], corrupting subsequent writes.
+        MessagePackFactory factory = new MessagePackFactory();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+
+        generator.writeStartArray();
+        generator.writeNumber(1);
+        generator.writeEndArray();
+
+        generator.writeStartArray();        // second root — isElementsClosed still true
+        generator.flush();                  // must NOT pack the incomplete second array
+        generator.writeNumber(2);
+        generator.writeEndArray();
+
+        generator.close();
+
+        ObjectMapper mapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+        try (JsonParser parser =
+                new MessagePackFactory().createParser(ObjectReadContext.empty(), baos.toByteArray())) {
+            List<Integer> first = mapper.readValue(parser, new TypeReference<List<Integer>>() {});
+            assertEquals(Collections.singletonList(1), first);
+            List<Integer> second = mapper.readValue(parser, new TypeReference<List<Integer>>() {});
+            assertEquals(Collections.singletonList(2), second);
+        }
+    }
+
+    @Test
+    public void testRootScalarAfterClosedRootContainerPreservesOrder()
+            throws IOException
+    {
+        // A root scalar written after a closed root container must be emitted AFTER
+        // the container, not before. Without a fix, addValueNode() packs the scalar
+        // immediately (default branch) while the container stays buffered, reversing order.
+        MessagePackFactory factory = new MessagePackFactory();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeNumber(1);
+        generator.writeEndArray();
+        generator.writeNumber(2);  // root scalar — must come AFTER the array
+        generator.close();
+
+        ObjectMapper mapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+        try (JsonParser parser =
+                new MessagePackFactory().createParser(ObjectReadContext.empty(), baos.toByteArray())) {
+            List<Integer> list = mapper.readValue(parser, new TypeReference<List<Integer>>() {});
+            assertEquals(Collections.singletonList(1), list);
+            int scalar = mapper.readValue(parser, Integer.class);
+            assertEquals(2, scalar);
+        }
+    }
+
+    // Bug: writeNumber(String) is missing "return this" after addValueNode(d) in the
+    // NaN/Infinity fallback branch.  addValueNode() advances the write-context state
+    // and (for root-level scalars) writes bytes to the output stream before the
+    // method falls through to "throw new NumberFormatException(encodedValue)".
+    @Test
+    public void testWriteNumberStringNanAndInfinity() throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        // Avoid try-with-resources: if writeNumber throws, the implicit close
+        // flushes a half-written node list and masks the original failure.
+        JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        gen.writeStartArray();
+        gen.writeNumber("NaN");       // Bug: NFE thrown after state mutation
+        gen.writeNumber("Infinity");
+        gen.writeNumber("-Infinity");
+        gen.writeEndArray();
+        gen.close();
+
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), baos.toByteArray())) {
+            assertEquals(JsonToken.START_ARRAY, p.nextToken());
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertTrue(Double.isNaN(p.getDoubleValue()));
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(Double.POSITIVE_INFINITY, p.getDoubleValue(), 0);
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(Double.NEGATIVE_INFINITY, p.getDoubleValue(), 0);
+            assertEquals(JsonToken.END_ARRAY, p.nextToken());
+        }
+    }
+
+    // Bug: same DupDetector NPE as the read-path bug, on the write side.
+    // writeName(SerializableString) calls writeContext.writeName(name.getValue())
+    // where MessagePackSerializedString(null).getValue() == null.  With
+    // STRICT_DUPLICATE_DETECTION enabled and a prior non-null key already seen,
+    // DupDetector.isDup(null) reaches name.equals(_firstName) → NPE.
+    @Test
+    public void testNullKeyWithWriteDupDetectionDoesNotNPE() throws IOException
+    {
+        MessagePackFactory f = new MessagePackFactoryBuilder()
+                .enable(StreamWriteFeature.STRICT_DUPLICATE_DETECTION)
+                .build();
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = f.createGenerator(ObjectWriteContext.empty(), baos)) {
+            gen.writeStartObject();
+            gen.writeName("foo");
+            gen.writeNumber(1);
+            // MessagePackSerializedString(null).getValue() == null
+            gen.writeName(new MessagePackSerializedString(null)); // Bug: NPE here
+            gen.writeNumber(2);
+            gen.writeEndObject();
+        }
+    }
+
+    // Bug: MessagePackSerializedString.charLength() calls getValue().length()
+    // unconditionally; getValue() returns null when value is null → NPE.
+    @Test
+    public void testSerializedStringNullValueCharLengthDoesNotNPE()
+    {
+        MessagePackSerializedString s = new MessagePackSerializedString(null);
+        // Bug: null.length() → NullPointerException
+        assertEquals(0, s.charLength());
+    }
+
+    @Test
+    public void testMultipleRootContainersWithoutFlush()
+            throws IOException
+    {
+        // Writing two consecutive root-level containers on the same generator without
+        // an intervening flush() must not throw IndexOutOfBoundsException.
+        // The second root container sits at node index 1, so the root check
+        // "currentParentElementIndex == 0" incorrectly falls through to the
+        // nested-container path and calls nodes.get(-1).
+        MessagePackFactory factory = new MessagePackFactory();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        JsonGenerator generator = factory.createGenerator(ObjectWriteContext.empty(), baos);
+        generator.writeStartArray();
+        generator.writeNumber(1);
+        generator.writeEndArray();
+        // second root container — no flush() in between
+        generator.writeStartObject();
+        generator.writeStringProperty("key", "value");
+        generator.writeEndObject();
+        generator.close();
+
+        // Verify both values were written correctly by reading from a shared parser
+        ObjectMapper mapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+        try (JsonParser parser =
+                new MessagePackFactory().createParser(ObjectReadContext.empty(), baos.toByteArray())) {
+            List<Integer> list = mapper.readValue(parser, new TypeReference<List<Integer>>() {});
+            assertEquals(Collections.singletonList(1), list);
+            Map<String, String> map = mapper.readValue(parser, new TypeReference<Map<String, String>>() {});
+            assertEquals(Collections.singletonMap("key", "value"), map);
+        }
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackMapperTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackMapperTest.java
@@ -1,0 +1,117 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JacksonException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class MessagePackMapperTest
+{
+    static class PojoWithBigInteger
+    {
+        public BigInteger value;
+    }
+
+    static class PojoWithBigDecimal
+    {
+        public BigDecimal value;
+    }
+
+    private void shouldFailToHandleBigInteger(MessagePackMapper messagePackMapper) throws JacksonException
+    {
+        PojoWithBigInteger obj = new PojoWithBigInteger();
+        obj.value = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(10));
+
+        try {
+            messagePackMapper.writeValueAsBytes(obj);
+            fail();
+        }
+        catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    private void shouldSuccessToHandleBigInteger(MessagePackMapper messagePackMapper) throws IOException
+    {
+        PojoWithBigInteger obj = new PojoWithBigInteger();
+        obj.value = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(10));
+
+        byte[] converted = messagePackMapper.writeValueAsBytes(obj);
+
+        PojoWithBigInteger deserialized = messagePackMapper.readValue(converted, PojoWithBigInteger.class);
+        assertEquals(obj.value, deserialized.value);
+    }
+
+    private void shouldFailToHandleBigDecimal(MessagePackMapper messagePackMapper) throws JacksonException
+    {
+        PojoWithBigDecimal obj = new PojoWithBigDecimal();
+        obj.value = new BigDecimal("1234567890.98765432100");
+
+        try {
+            messagePackMapper.writeValueAsBytes(obj);
+            fail();
+        }
+        catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    private void shouldSuccessToHandleBigDecimal(MessagePackMapper messagePackMapper) throws IOException
+    {
+        PojoWithBigDecimal obj = new PojoWithBigDecimal();
+        obj.value = new BigDecimal("1234567890.98765432100");
+
+        byte[] converted = messagePackMapper.writeValueAsBytes(obj);
+
+        PojoWithBigDecimal deserialized = messagePackMapper.readValue(converted, PojoWithBigDecimal.class);
+        assertEquals(obj.value, deserialized.value);
+    }
+
+    @Test
+    public void handleBigIntegerAsString() throws IOException
+    {
+        shouldFailToHandleBigInteger(new MessagePackMapper());
+        shouldSuccessToHandleBigInteger(MessagePackMapper.builder()
+                .handleBigIntegerAsString()
+                .build());
+    }
+
+    @Test
+    public void handleBigDecimalAsString() throws IOException
+    {
+        shouldFailToHandleBigDecimal(new MessagePackMapper());
+        shouldSuccessToHandleBigDecimal(MessagePackMapper.builder()
+                .handleBigDecimalAsString()
+                .build());
+    }
+
+    @Test
+    public void handleBigIntegerAndBigDecimalAsString() throws IOException
+    {
+        MessagePackMapper messagePackMapper = MessagePackMapper.builder()
+                .handleBigIntegerAndBigDecimalAsString()
+                .build();
+        shouldSuccessToHandleBigInteger(messagePackMapper);
+        shouldSuccessToHandleBigDecimal(messagePackMapper);
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackParserTest.java
@@ -1,0 +1,1524 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.ObjectReadContext;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.exc.UnexpectedEndOfInputException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.KeyDeserializer;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.module.SimpleModule;
+import org.junit.Test;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.value.ExtensionValue;
+import org.msgpack.value.MapValue;
+import org.msgpack.value.ValueFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+
+public class MessagePackParserTest
+        extends MessagePackDataformatTestBase
+{
+    @Test
+    public void testParserShouldReadObject()
+            throws IOException
+    {
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packMapHeader(9);
+        // #1
+        packer.packString("str");
+        packer.packString("foobar");
+        // #2
+        packer.packString("int");
+        packer.packInt(Integer.MIN_VALUE);
+        // #3
+        packer.packString("map");
+        {
+            packer.packMapHeader(2);
+            packer.packString("child_str");
+            packer.packString("bla bla bla");
+            packer.packString("child_int");
+            packer.packInt(Integer.MAX_VALUE);
+        }
+        // #4
+        packer.packString("double");
+        packer.packDouble(Double.MAX_VALUE);
+        // #5
+        packer.packString("long");
+        packer.packLong(Long.MIN_VALUE);
+        // #6
+        packer.packString("bi");
+        BigInteger bigInteger = new BigInteger(Long.toString(Long.MAX_VALUE));
+        packer.packBigInteger(bigInteger.add(BigInteger.ONE));
+        // #7
+        packer.packString("array");
+        {
+            packer.packArrayHeader(3);
+            packer.packFloat(Float.MIN_VALUE);
+            packer.packNil();
+            packer.packString("array_child_str");
+        }
+        // #8
+        packer.packString("bool");
+        packer.packBoolean(false);
+        // #9
+        byte[] extPayload = {-80, -50, -25, -114, -25, 16, 60, 68};
+        packer.packString("ext");
+        packer.packExtensionTypeHeader((byte) 0, extPayload.length);
+        packer.writePayload(extPayload);
+
+        packer.flush();
+
+        byte[] bytes = out.toByteArray();
+
+        TypeReference<Map<String, Object>> typeReference = new TypeReference<Map<String, Object>>() {};
+        Map<String, Object> object = objectMapper.readValue(bytes, typeReference);
+        assertEquals(9, object.keySet().size());
+
+        int bitmap = 0;
+        for (Map.Entry<String, Object> entry : object.entrySet()) {
+            String k = entry.getKey();
+            Object v = entry.getValue();
+            if (k.equals("str")) {
+                // #1
+                bitmap |= 1 << 0;
+                assertEquals("foobar", v);
+            }
+            else if (k.equals("int")) {
+                // #2
+                bitmap |= 1 << 1;
+                assertEquals(Integer.MIN_VALUE, v);
+            }
+            else if (k.equals("map")) {
+                // #3
+                bitmap |= 1 << 2;
+                @SuppressWarnings("unchecked")
+                Map<String, Object> child = (Map<String, Object>) v;
+                assertEquals(2, child.keySet().size());
+                for (Map.Entry<String, Object> childEntry : child.entrySet()) {
+                    String ck = childEntry.getKey();
+                    Object cv = childEntry.getValue();
+                    if (ck.equals("child_str")) {
+                        bitmap |= 1 << 3;
+                        assertEquals("bla bla bla", cv);
+                    }
+                    else if (ck.equals("child_int")) {
+                        bitmap |= 1 << 4;
+                        assertEquals(Integer.MAX_VALUE, cv);
+                    }
+                }
+            }
+            else if (k.equals("double")) {
+                // #4
+                bitmap |= 1 << 5;
+                assertEquals(Double.MAX_VALUE, (Double) v, 0.0001f);
+            }
+            else if (k.equals("long")) {
+                // #5
+                bitmap |= 1 << 6;
+                assertEquals(Long.MIN_VALUE, v);
+            }
+            else if (k.equals("bi")) {
+                // #6
+                bitmap |= 1 << 7;
+                BigInteger bi = new BigInteger(Long.toString(Long.MAX_VALUE));
+                assertEquals(bi.add(BigInteger.ONE), v);
+            }
+            else if (k.equals("array")) {
+                // #7
+                bitmap |= 1 << 8;
+                @SuppressWarnings("unchecked")
+                List<? extends Serializable> expected = Arrays.asList((double) Float.MIN_VALUE, null, "array_child_str");
+                assertEquals(expected, v);
+            }
+            else if (k.equals("bool")) {
+                // #8
+                bitmap |= 1 << 9;
+                assertEquals(false, v);
+            }
+            else if (k.equals("ext")) {
+                // #9
+                bitmap |= 1 << 10;
+                MessagePackExtensionType extensionType = (MessagePackExtensionType) v;
+                assertEquals(0, extensionType.getType());
+                assertArrayEquals(extPayload, extensionType.getData());
+            }
+        }
+        assertEquals(0x7FF, bitmap);
+    }
+
+    @Test
+    public void testParserShouldReadArray()
+            throws IOException
+    {
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packArrayHeader(11);
+        // #1
+        packer.packArrayHeader(3);
+        {
+            packer.packLong(Long.MAX_VALUE);
+            packer.packNil();
+            packer.packString("FOO BAR");
+        }
+        // #2
+        packer.packString("str");
+        // #3
+        packer.packInt(Integer.MAX_VALUE);
+        // #4
+        packer.packLong(Long.MIN_VALUE);
+        // #5
+        packer.packFloat(Float.MAX_VALUE);
+        // #6
+        packer.packDouble(Double.MIN_VALUE);
+        // #7
+        BigInteger bi = new BigInteger(Long.toString(Long.MAX_VALUE));
+        bi = bi.add(BigInteger.ONE);
+        packer.packBigInteger(bi);
+        // #8
+        byte[] bytes = new byte[] {(byte) 0xFF, (byte) 0xFE, 0x01, 0x00};
+        packer.packBinaryHeader(bytes.length);
+        packer.writePayload(bytes);
+        // #9
+        packer.packMapHeader(2);
+        {
+            packer.packString("child_map_name");
+            packer.packString("komamitsu");
+            packer.packString("child_map_age");
+            packer.packInt(42);
+        }
+        // #10
+        packer.packBoolean(true);
+        // #11
+        byte[] extPayload = {-80, -50, -25, -114, -25, 16, 60, 68};
+        packer.packExtensionTypeHeader((byte) -1, extPayload.length);
+        packer.writePayload(extPayload);
+
+        packer.flush();
+
+        bytes = out.toByteArray();
+
+        TypeReference<List<Object>> typeReference = new TypeReference<List<Object>>() {};
+        List<Object> array = objectMapper.readValue(bytes, typeReference);
+        assertEquals(11, array.size());
+        int i = 0;
+        // #1
+        @SuppressWarnings("unchecked")
+        List<Object> childArray = (List<Object>) array.get(i++);
+        {
+            int j = 0;
+            assertEquals(Long.MAX_VALUE, childArray.get(j++));
+            assertEquals(null, childArray.get(j++));
+            assertEquals("FOO BAR", childArray.get(j++));
+        }
+        // #2
+        assertEquals("str", array.get(i++));
+        // #3
+        assertEquals(Integer.MAX_VALUE, array.get(i++));
+        // #4
+        assertEquals(Long.MIN_VALUE, array.get(i++));
+        // #5
+        assertEquals(Float.MAX_VALUE, (Double) array.get(i++), 0.001f);
+        // #6
+        assertEquals(Double.MIN_VALUE, (Double) array.get(i++), 0.001f);
+        // #7
+        assertEquals(bi, array.get(i++));
+        // #8
+        byte[] bs = (byte[]) array.get(i++);
+        assertEquals(4, bs.length);
+        assertEquals((byte) 0xFF, bs[0]);
+        assertEquals((byte) 0xFE, bs[1]);
+        assertEquals((byte) 0x01, bs[2]);
+        assertEquals((byte) 0x00, bs[3]);
+        // #9
+        @SuppressWarnings("unchecked")
+        Map<String, Object> childMap = (Map<String, Object>) array.get(i++);
+        {
+            assertEquals(2, childMap.keySet().size());
+            for (Map.Entry<String, Object> entry : childMap.entrySet()) {
+                String k = entry.getKey();
+                Object v = entry.getValue();
+                if (k.equals("child_map_name")) {
+                    assertEquals("komamitsu", v);
+                }
+                else if (k.equals("child_map_age")) {
+                    assertEquals(42, v);
+                }
+            }
+        }
+        // #10
+        assertEquals(true, array.get(i++));
+        // #11
+        MessagePackExtensionType extensionType = (MessagePackExtensionType) array.get(i++);
+        assertEquals(-1, extensionType.getType());
+        assertArrayEquals(extPayload, extensionType.getData());
+    }
+
+    @Test
+    public void testMessagePackParserDirectly()
+            throws IOException
+    {
+        MessagePackFactory factory = new MessagePackFactory();
+        File tempFile = File.createTempFile("msgpackTest", "msgpack");
+        tempFile.deleteOnExit();
+
+        FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
+        MessagePacker packer = MessagePack.newDefaultPacker(fileOutputStream);
+        packer.packMapHeader(2);
+        packer.packString("zero");
+        packer.packInt(0);
+        packer.packString("one");
+        packer.packFloat(1.0f);
+        packer.close();
+
+        JsonParser parser = factory.createParser(tempFile);
+        assertTrue(parser instanceof MessagePackParser);
+
+        JsonToken jsonToken = parser.nextToken();
+        assertEquals(JsonToken.START_OBJECT, jsonToken);
+        assertEquals(-1, parser.currentTokenLocation().getLineNr());
+        assertEquals(0, parser.currentTokenLocation().getColumnNr());
+        assertEquals(-1, parser.currentLocation().getLineNr());
+        assertEquals(1, parser.currentLocation().getColumnNr());
+
+        jsonToken = parser.nextToken();
+        assertEquals(JsonToken.PROPERTY_NAME, jsonToken);
+        assertEquals("zero", parser.currentName());
+        assertEquals(1, parser.currentTokenLocation().getColumnNr());
+        assertEquals(6, parser.currentLocation().getColumnNr());
+
+        jsonToken = parser.nextToken();
+        assertEquals(JsonToken.VALUE_NUMBER_INT, jsonToken);
+        assertEquals(0, parser.getIntValue());
+        assertEquals(6, parser.currentTokenLocation().getColumnNr());
+        assertEquals(7, parser.currentLocation().getColumnNr());
+
+        jsonToken = parser.nextToken();
+        assertEquals(JsonToken.PROPERTY_NAME, jsonToken);
+        assertEquals("one", parser.currentName());
+        assertEquals(7, parser.currentTokenLocation().getColumnNr());
+        assertEquals(11, parser.currentLocation().getColumnNr());
+
+        jsonToken = parser.nextToken();
+        assertEquals(JsonToken.VALUE_NUMBER_FLOAT, jsonToken);
+        assertEquals(1.0f, parser.getIntValue(), 0.001f);
+        assertEquals(11, parser.currentTokenLocation().getColumnNr());
+        assertEquals(16, parser.currentLocation().getColumnNr());
+
+        jsonToken = parser.nextToken();
+        assertEquals(JsonToken.END_OBJECT, jsonToken);
+        assertEquals(-1, parser.currentTokenLocation().getLineNr());
+        assertEquals(16, parser.currentTokenLocation().getColumnNr());
+        assertEquals(-1, parser.currentLocation().getLineNr());
+        assertEquals(16, parser.currentLocation().getColumnNr());
+
+        parser.close();
+        parser.close(); // Intentional
+    }
+
+    @Test
+    public void testReadPrimitives()
+            throws Exception
+    {
+        MessagePackFactory factory = new MessagePackFactory();
+        File tempFile = createTempFile();
+
+        FileOutputStream out = new FileOutputStream(tempFile);
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packString("foo");
+        packer.packDouble(3.14);
+        packer.packInt(Integer.MIN_VALUE);
+        packer.packLong(Long.MAX_VALUE);
+        packer.packBigInteger(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE));
+        byte[] bytes = {0x00, 0x11, 0x22};
+        packer.packBinaryHeader(bytes.length);
+        packer.writePayload(bytes);
+        packer.close();
+
+        JsonParser parser = factory.createParser(new FileInputStream(tempFile));
+        assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+        assertEquals("foo", parser.getString());
+
+        assertEquals(JsonToken.VALUE_NUMBER_FLOAT, parser.nextToken());
+        assertEquals(3.14, parser.getDoubleValue(), 0.0001);
+        assertEquals("3.14", parser.getString());
+
+        assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(Integer.MIN_VALUE, parser.getIntValue());
+        assertEquals(Integer.MIN_VALUE, parser.getLongValue());
+        assertEquals("-2147483648", parser.getString());
+
+        assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(Long.MAX_VALUE, parser.getLongValue());
+        assertEquals("9223372036854775807", parser.getString());
+
+        assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), parser.getBigIntegerValue());
+        assertEquals("9223372036854775808", parser.getString());
+
+        assertEquals(JsonToken.VALUE_EMBEDDED_OBJECT, parser.nextToken());
+        assertEquals(bytes.length, parser.getBinaryValue().length);
+        assertEquals(bytes[0], parser.getBinaryValue()[0]);
+        assertEquals(bytes[1], parser.getBinaryValue()[1]);
+        assertEquals(bytes[2], parser.getBinaryValue()[2]);
+    }
+
+    @Test
+    public void testBigDecimal()
+            throws IOException
+    {
+        double d0 = 1.23456789;
+        double d1 = 1.23450000000000000000006789;
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packArrayHeader(5);
+        packer.packDouble(d0);
+        packer.packDouble(d1);
+        packer.packDouble(Double.MIN_VALUE);
+        packer.packDouble(Double.MAX_VALUE);
+        packer.packDouble(Double.MIN_NORMAL);
+        packer.flush();
+
+        ObjectMapper mapper = MessagePackMapper.builder(new MessagePackFactory())
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+                .build();
+        List<Object> objects = mapper.readValue(out.toByteArray(), new TypeReference<List<Object>>() {});
+        assertEquals(5, objects.size());
+        int idx = 0;
+        assertEquals(BigDecimal.valueOf(d0), objects.get(idx++));
+        assertEquals(BigDecimal.valueOf(d1), objects.get(idx++));
+        assertEquals(BigDecimal.valueOf(Double.MIN_VALUE), objects.get(idx++));
+        assertEquals(BigDecimal.valueOf(Double.MAX_VALUE), objects.get(idx++));
+        assertEquals(BigDecimal.valueOf(Double.MIN_NORMAL), objects.get(idx++));
+    }
+
+    private File createTestFile()
+            throws Exception
+    {
+        File tempFile = createTempFile(new FileSetup()
+        {
+            @Override
+            public void setup(File f)
+                    throws IOException
+            {
+                MessagePack.newDefaultPacker(new FileOutputStream(f))
+                        .packArrayHeader(1).packInt(1)
+                        .packArrayHeader(1).packInt(1)
+                        .close();
+            }
+        });
+        return tempFile;
+    }
+
+    @Test
+    public void testEnableFeatureAutoCloseSource()
+            throws Exception
+    {
+        File tempFile = createTestFile();
+        MessagePackFactory factory = new MessagePackFactory();
+        FileInputStream in = new FileInputStream(tempFile);
+        ObjectMapper objectMapper = MessagePackMapper.builder(factory)
+                .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+        objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
+        assertThrows(JacksonException.class, () -> {
+            objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
+        });
+    }
+
+    @Test
+    public void testDisableFeatureAutoCloseSource()
+            throws Exception
+    {
+        File tempFile = createTestFile();
+        FileInputStream in = new FileInputStream(tempFile);
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(tools.jackson.core.StreamReadFeature.AUTO_CLOSE_SOURCE)
+                .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+        objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
+        objectMapper.readValue(in, new TypeReference<List<Integer>>() {});
+    }
+
+    @Test
+    public void testParseBigDecimal()
+            throws IOException
+    {
+        ArrayList<BigDecimal> list = new ArrayList<BigDecimal>();
+        list.add(new BigDecimal(Long.MAX_VALUE));
+        ObjectMapper objectMapper = new MessagePackMapper(new MessagePackFactory());
+        byte[] bytes = objectMapper.writeValueAsBytes(list);
+
+        ArrayList<BigDecimal> result = objectMapper.readValue(
+                bytes, new TypeReference<ArrayList<BigDecimal>>() {});
+        assertEquals(list, result);
+    }
+
+    @Test
+    public void testReadPrimitiveObjectViaObjectMapper()
+            throws Exception
+    {
+        File tempFile = createTempFile();
+        FileOutputStream out = new FileOutputStream(tempFile);
+
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packString("foo");
+        packer.packLong(Long.MAX_VALUE);
+        packer.packDouble(3.14);
+        byte[] bytes = {0x00, 0x11, 0x22};
+        packer.packBinaryHeader(bytes.length);
+        packer.writePayload(bytes);
+        packer.close();
+
+        FileInputStream in = new FileInputStream(tempFile);
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(tools.jackson.core.StreamReadFeature.AUTO_CLOSE_SOURCE)
+                .disable(tools.jackson.databind.DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+        assertEquals("foo", objectMapper.readValue(in, new TypeReference<String>() {}));
+        long l = objectMapper.readValue(in, new TypeReference<Long>() {});
+        assertEquals(Long.MAX_VALUE, l);
+        double d = objectMapper.readValue(in, new TypeReference<Double>() {});
+        assertEquals(3.14, d, 0.001);
+        byte[] bs = objectMapper.readValue(in, new TypeReference<byte[]>() {});
+        assertEquals(bytes.length, bs.length);
+        assertEquals(bytes[0], bs[0]);
+        assertEquals(bytes[1], bs[1]);
+        assertEquals(bytes[2], bs[2]);
+    }
+
+    @Test
+    public void testBinaryKey()
+            throws Exception
+    {
+        File tempFile = createTempFile();
+        FileOutputStream out = new FileOutputStream(tempFile);
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packMapHeader(2);
+        packer.packString("foo");
+        packer.packDouble(3.14);
+        byte[] bytes = "bar".getBytes();
+        packer.packBinaryHeader(bytes.length);
+        packer.writePayload(bytes);
+        packer.packLong(42);
+        packer.close();
+
+        ObjectMapper mapper = new MessagePackMapper(new MessagePackFactory());
+        Map<String, Object> object = mapper.readValue(new FileInputStream(tempFile), new TypeReference<Map<String, Object>>() {});
+        assertEquals(2, object.size());
+        assertEquals(3.14, object.get("foo"));
+        assertEquals(42, object.get("bar"));
+    }
+
+    @Test
+    public void testBinaryKeyInNestedObject()
+            throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packArrayHeader(2);
+        packer.packMapHeader(1);
+        byte[] bytes = "bar".getBytes();
+        packer.packBinaryHeader(bytes.length);
+        packer.writePayload(bytes);
+        packer.packInt(12);
+        packer.packInt(1);
+        packer.close();
+
+        ObjectMapper mapper = new MessagePackMapper(new MessagePackFactory());
+        List<Object> objects = mapper.readValue(out.toByteArray(), new TypeReference<List<Object>>() {});
+        assertEquals(2, objects.size());
+        @SuppressWarnings(value = "unchecked")
+        Map<String, Object> map = (Map<String, Object>) objects.get(0);
+        assertEquals(1, map.size());
+        assertEquals(12, map.get("bar"));
+        assertEquals(1, objects.get(1));
+    }
+
+    @Test
+    public void testByteArrayKey()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker messagePacker = MessagePack.newDefaultPacker(out).packMapHeader(2);
+        byte[] k0 = new byte[] {0};
+        byte[] k1 = new byte[] {1};
+        messagePacker.packBinaryHeader(1).writePayload(k0).packInt(10);
+        messagePacker.packBinaryHeader(1).writePayload(k1).packInt(11);
+        messagePacker.close();
+
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule()
+                        .addKeyDeserializer(byte[].class, new KeyDeserializer()
+                        {
+                            @Override
+                            public Object deserializeKey(String key, DeserializationContext ctxt)
+                                    throws JacksonException
+                            {
+                                return key.getBytes();
+                            }
+                        }))
+                .build();
+
+        Map<byte[], Integer> map = objectMapper.readValue(
+                out.toByteArray(), new TypeReference<Map<byte[], Integer>>() {});
+        assertEquals(2, map.size());
+        for (Map.Entry<byte[], Integer> entry : map.entrySet()) {
+            if (Arrays.equals(entry.getKey(), k0)) {
+                assertEquals((Integer) 10, entry.getValue());
+            }
+            else if (Arrays.equals(entry.getKey(), k1)) {
+                assertEquals((Integer) 11, entry.getValue());
+            }
+        }
+    }
+
+    @Test
+    public void testIntegerKey()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker messagePacker = MessagePack.newDefaultPacker(out).packMapHeader(2);
+        for (int i = 0; i < 2; i++) {
+            messagePacker.packInt(i).packInt(i + 10);
+        }
+        messagePacker.close();
+
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule()
+                        .addKeyDeserializer(Integer.class, new KeyDeserializer()
+                        {
+                            @Override
+                            public Object deserializeKey(String key, DeserializationContext ctxt)
+                                    throws JacksonException
+                            {
+                                return Integer.valueOf(key);
+                            }
+                        }))
+                .build();
+
+        Map<Integer, Integer> map = objectMapper.readValue(
+                out.toByteArray(), new TypeReference<Map<Integer, Integer>>() {});
+        assertEquals(2, map.size());
+        assertEquals((Integer) 10, map.get(0));
+        assertEquals((Integer) 11, map.get(1));
+    }
+
+    @Test
+    public void testFloatKey()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker messagePacker = MessagePack.newDefaultPacker(out).packMapHeader(2);
+        for (int i = 0; i < 2; i++) {
+            messagePacker.packFloat(i).packInt(i + 10);
+        }
+        messagePacker.close();
+
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule()
+                        .addKeyDeserializer(Float.class, new KeyDeserializer()
+                        {
+                            @Override
+                            public Object deserializeKey(String key, DeserializationContext ctxt)
+                                    throws JacksonException
+                            {
+                                return Float.valueOf(key);
+                            }
+                        }))
+                .build();
+
+        Map<Float, Integer> map = objectMapper.readValue(
+                out.toByteArray(), new TypeReference<Map<Float, Integer>>() {});
+        assertEquals(2, map.size());
+        assertEquals((Integer) 10, map.get(0f));
+        assertEquals((Integer) 11, map.get(1f));
+    }
+
+    @Test
+    public void testBooleanKey()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker messagePacker = MessagePack.newDefaultPacker(out).packMapHeader(2);
+        messagePacker.packBoolean(true).packInt(10);
+        messagePacker.packBoolean(false).packInt(11);
+        messagePacker.close();
+
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(new SimpleModule()
+                        .addKeyDeserializer(Boolean.class, new KeyDeserializer()
+                        {
+                            @Override
+                            public Object deserializeKey(String key, DeserializationContext ctxt)
+                                    throws JacksonException
+                            {
+                                return Boolean.valueOf(key);
+                            }
+                        }))
+                .build();
+
+        Map<Boolean, Integer> map = objectMapper.readValue(
+                out.toByteArray(), new TypeReference<Map<Boolean, Integer>>() {});
+        assertEquals(2, map.size());
+        assertEquals((Integer) 10, map.get(true));
+        assertEquals((Integer) 11, map.get(false));
+    }
+
+    @Test
+    public void testNilKey()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker packer = MessagePack.newDefaultPacker(out).packMapHeader(1);
+        packer.packNil();
+        packer.packInt(42);
+        packer.close();
+
+        JsonParser parser = new MessagePackMapper().createParser(out.toByteArray());
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.PROPERTY_NAME, parser.nextToken());
+        assertNull(parser.currentName());
+        assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(42, parser.getIntValue());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        parser.close();
+    }
+
+    @Test
+    public void extensionTypeCustomDeserializers()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packArrayHeader(3);
+        // 0: Integer
+        packer.packInt(42);
+        // 1: String
+        packer.packString("foo bar");
+        // 2: ExtensionType
+        {
+            packer.packExtensionTypeHeader((byte) 31, 4);
+            packer.addPayload(new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE});
+        }
+        packer.close();
+
+        ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+        extTypeCustomDesers.addCustomDeser((byte) 31, new ExtensionTypeCustomDeserializers.Deser() {
+                    @Override
+                    public Object deserialize(byte[] data)
+                            throws IOException
+                    {
+                        if (Arrays.equals(data, new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE})) {
+                            return "Java";
+                        }
+                        return "Not Java";
+                    }
+                }
+        );
+        ObjectMapper objectMapper =
+                new MessagePackMapper(new MessagePackFactory().setExtTypeCustomDesers(extTypeCustomDesers));
+
+        List<Object> values = objectMapper.readValue(new ByteArrayInputStream(out.toByteArray()), new TypeReference<List<Object>>() {});
+        assertThat(values.size(), is(3));
+        assertThat((Integer) values.get(0), is(42));
+        assertThat((String) values.get(1), is("foo bar"));
+        assertThat((String) values.get(2), is("Java"));
+    }
+
+    static class TripleBytesPojo
+    {
+        public byte first;
+        public byte second;
+        public byte third;
+
+        public TripleBytesPojo(byte first, byte second, byte third)
+        {
+            this.first = first;
+            this.second = second;
+            this.third = third;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TripleBytesPojo)) {
+                return false;
+            }
+
+            TripleBytesPojo that = (TripleBytesPojo) o;
+
+            if (first != that.first) {
+                return false;
+            }
+            if (second != that.second) {
+                return false;
+            }
+            return third == that.third;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = first;
+            result = 31 * result + (int) second;
+            result = 31 * result + (int) third;
+            return result;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("%d-%d-%d", first, second, third);
+        }
+
+        static class Deserializer
+                extends StdDeserializer<TripleBytesPojo>
+        {
+            protected Deserializer()
+            {
+                super(TripleBytesPojo.class);
+            }
+
+            @Override
+            public TripleBytesPojo deserialize(JsonParser p, DeserializationContext ctxt)
+                    throws JacksonException
+            {
+                return TripleBytesPojo.deserialize(p.getBinaryValue());
+            }
+        }
+
+        static class TripleBytesKeyDeserializer
+                extends KeyDeserializer
+        {
+            @Override
+            public Object deserializeKey(String key, DeserializationContext ctxt)
+                    throws JacksonException
+            {
+                String[] values = key.split("-");
+                return new TripleBytesPojo(
+                        Byte.parseByte(values[0]),
+                        Byte.parseByte(values[1]),
+                        Byte.parseByte(values[2]));
+            }
+        }
+
+        static byte[] serialize(TripleBytesPojo obj)
+        {
+            return new byte[] { obj.first, obj.second, obj.third };
+        }
+
+        static TripleBytesPojo deserialize(byte[] bytes)
+        {
+            return new TripleBytesPojo(bytes[0], bytes[1], bytes[2]);
+        }
+    }
+
+    @Test
+    public void extensionTypeWithPojoInMap()
+            throws IOException
+    {
+        byte extTypeCode = 42;
+
+        ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+        extTypeCustomDesers.addCustomDeser(extTypeCode, new ExtensionTypeCustomDeserializers.Deser()
+        {
+            @Override
+            public Object deserialize(byte[] value)
+                    throws IOException
+            {
+                return TripleBytesPojo.deserialize(value);
+            }
+        });
+
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(TripleBytesPojo.class, new TripleBytesPojo.Deserializer());
+        module.addKeyDeserializer(TripleBytesPojo.class, new TripleBytesPojo.TripleBytesKeyDeserializer());
+        ObjectMapper objectMapper = MessagePackMapper.builder(
+                new MessagePackFactory().setExtTypeCustomDesers(extTypeCustomDesers))
+                .addModule(module)
+                .build();
+
+        // Prepare serialized data
+        Map<TripleBytesPojo, TripleBytesPojo> originalMap = new HashMap<>();
+        byte[] serializedData;
+        {
+            ValueFactory.MapBuilder mapBuilder = ValueFactory.newMapBuilder();
+            for (int i = 0; i < 4; i++) {
+                TripleBytesPojo keyObj = new TripleBytesPojo((byte) i, (byte) (i + 1), (byte) (i + 2));
+                TripleBytesPojo valueObj = new TripleBytesPojo((byte) (i * 2), (byte) (i * 3), (byte) (i * 4));
+                ExtensionValue k = ValueFactory.newExtension(extTypeCode, TripleBytesPojo.serialize(keyObj));
+                ExtensionValue v = ValueFactory.newExtension(extTypeCode, TripleBytesPojo.serialize(valueObj));
+                mapBuilder.put(k, v);
+                originalMap.put(keyObj, valueObj);
+            }
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            MessagePacker packer = MessagePack.newDefaultPacker(output);
+            MapValue mapValue = mapBuilder.build();
+            mapValue.writeTo(packer);
+            packer.close();
+
+            serializedData = output.toByteArray();
+        }
+
+        Map<TripleBytesPojo, TripleBytesPojo> deserializedMap = objectMapper.readValue(serializedData,
+                new TypeReference<Map<TripleBytesPojo, TripleBytesPojo>>() {});
+
+        assertEquals(originalMap.size(), deserializedMap.size());
+        for (Map.Entry<TripleBytesPojo, TripleBytesPojo> entry : originalMap.entrySet()) {
+            assertEquals(entry.getValue(), deserializedMap.get(entry.getKey()));
+        }
+    }
+
+    @Test
+    public void extensionTypeWithUuidInMap()
+            throws IOException
+    {
+        byte extTypeCode = 42;
+
+        ExtensionTypeCustomDeserializers extTypeCustomDesers = new ExtensionTypeCustomDeserializers();
+        extTypeCustomDesers.addCustomDeser(extTypeCode, new ExtensionTypeCustomDeserializers.Deser()
+        {
+            @Override
+            public Object deserialize(byte[] value)
+                    throws IOException
+            {
+                return UUID.fromString(new String(value));
+            }
+        });
+
+        ObjectMapper objectMapper =
+                new MessagePackMapper(new MessagePackFactory().setExtTypeCustomDesers(extTypeCustomDesers));
+
+        // Prepare serialized data
+        Map<UUID, UUID> originalMap = new HashMap<>();
+        byte[] serializedData;
+        {
+            ValueFactory.MapBuilder mapBuilder = ValueFactory.newMapBuilder();
+            for (int i = 0; i < 4; i++) {
+                UUID keyObj = UUID.randomUUID();
+                UUID valueObj = UUID.randomUUID();
+                ExtensionValue k = ValueFactory.newExtension(extTypeCode, keyObj.toString().getBytes());
+                ExtensionValue v = ValueFactory.newExtension(extTypeCode, valueObj.toString().getBytes());
+                mapBuilder.put(k, v);
+                originalMap.put(keyObj, valueObj);
+            }
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            MessagePacker packer = MessagePack.newDefaultPacker(output);
+            MapValue mapValue = mapBuilder.build();
+            mapValue.writeTo(packer);
+            packer.close();
+
+            serializedData = output.toByteArray();
+        }
+
+        Map<UUID, UUID> deserializedMap = objectMapper.readValue(serializedData,
+                new TypeReference<Map<UUID, UUID>>() {});
+
+        assertEquals(originalMap.size(), deserializedMap.size());
+        for (Map.Entry<UUID, UUID> entry : originalMap.entrySet()) {
+            assertEquals(entry.getValue(), deserializedMap.get(entry.getKey()));
+        }
+    }
+
+    @Test
+    public void parserShouldReadStrAsBin()
+            throws IOException
+    {
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packMapHeader(2);
+        // #1
+        packer.packString("s");
+        packer.packString("foo");
+        // #2
+        packer.packString("b");
+        packer.packString("bar");
+
+        packer.flush();
+
+        byte[] bytes = out.toByteArray();
+
+        BinKeyPojo binKeyPojo = objectMapper.readValue(bytes, BinKeyPojo.class);
+        assertEquals("foo", binKeyPojo.s);
+        assertArrayEquals("bar".getBytes(), binKeyPojo.b);
+    }
+
+    @Test
+    public void deserializeStringAsInteger()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePack.newDefaultPacker(out).packString(String.valueOf(Integer.MAX_VALUE)).close();
+
+        Integer v = objectMapper.readValue(out.toByteArray(), Integer.class);
+        assertThat(v, is(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void deserializeStringAsLong()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePack.newDefaultPacker(out).packString(String.valueOf(Long.MIN_VALUE)).close();
+
+        Long v = objectMapper.readValue(out.toByteArray(), Long.class);
+        assertThat(v, is(Long.MIN_VALUE));
+    }
+
+    @Test
+    public void deserializeStringAsFloat()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePack.newDefaultPacker(out).packString(String.valueOf(Float.MAX_VALUE)).close();
+
+        Float v = objectMapper.readValue(out.toByteArray(), Float.class);
+        assertThat(v, is(Float.MAX_VALUE));
+    }
+
+    @Test
+    public void deserializeStringAsDouble()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        MessagePack.newDefaultPacker(out).packString(String.valueOf(Double.MIN_VALUE)).close();
+
+        Double v = objectMapper.readValue(out.toByteArray(), Double.class);
+        assertThat(v, is(Double.MIN_VALUE));
+    }
+
+    @Test
+    public void deserializeStringAsBigInteger()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BigInteger bi = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        MessagePack.newDefaultPacker(out).packString(bi.toString()).close();
+
+        BigInteger v = objectMapper.readValue(out.toByteArray(), BigInteger.class);
+        assertThat(v, is(bi));
+    }
+
+    @Test
+    public void deserializeStringAsBigDecimal()
+            throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        BigDecimal bd = BigDecimal.valueOf(Double.MAX_VALUE);
+        MessagePack.newDefaultPacker(out).packString(bd.toString()).close();
+
+        BigDecimal v = objectMapper.readValue(out.toByteArray(), BigDecimal.class);
+        assertThat(v, is(bd));
+    }
+
+    @Test
+    public void handleMissingItemInArray()
+            throws IOException
+    {
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        packer.packArrayHeader(3);
+        packer.packString("one");
+        packer.packString("two");
+        packer.close();
+
+        assertThrows(UnexpectedEndOfInputException.class, () -> {
+            objectMapper.readValue(out.toByteArray(), new TypeReference<List<String>>() {});
+        });
+    }
+
+    @Test
+    public void handleMissingKeyValueInMap()
+    {
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        try {
+            packer.packMapHeader(3);
+            packer.packString("one");
+            packer.packInt(1);
+            packer.packString("two");
+            packer.packInt(2);
+            packer.close();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertThrows(JacksonException.class, () -> {
+            objectMapper.readValue(out.toByteArray(), new TypeReference<Map<String, Integer>>() {});
+        });
+    }
+
+    @Test
+    public void handleMissingValueInMap()
+    {
+        MessagePacker packer = MessagePack.newDefaultPacker(out);
+        try {
+            packer.packMapHeader(3);
+            packer.packString("one");
+            packer.packInt(1);
+            packer.packString("two");
+            packer.packInt(2);
+            packer.packString("three");
+            packer.close();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertThrows(JacksonException.class, () -> {
+            objectMapper.readValue(out.toByteArray(), new TypeReference<Map<String, Integer>>() {});
+        });
+    }
+
+    @Test
+    public void testByteArrayThreadLocalClearedAfterClose()
+            throws IOException
+    {
+        ObjectMapper objectMapper = new MessagePackMapper(new MessagePackFactory());
+
+        byte[] bytes = objectMapper.writeValueAsBytes(Arrays.asList(1, 2, 3));
+
+        // Parse once; this caches the byte array in the ThreadLocal
+        objectMapper.readValue(bytes, new TypeReference<List<Integer>>() {});
+
+        // Parse again with the same byte array instance and AUTO_CLOSE_SOURCE enabled
+        // (default). The byte array reference should have been cleared from the
+        // ThreadLocal on close, so the second parse resets the unpacker and starts
+        // from the beginning rather than continuing from the end.
+        List<Integer> result = objectMapper.readValue(bytes, new TypeReference<List<Integer>>() {});
+        assertEquals(Arrays.asList(1, 2, 3), result);
+    }
+
+    @Test
+    public void testByteArrayReuseResetsUnpackerWhenAutoCloseSourceDisabled()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(tools.jackson.core.StreamReadFeature.AUTO_CLOSE_SOURCE)
+                .build();
+
+        byte[] bytes = objectMapper.writeValueAsBytes(Arrays.asList(1, 2, 3));
+
+        // First parse succeeds
+        List<Integer> first = objectMapper.readValue(bytes, new TypeReference<List<Integer>>() {});
+        assertEquals(Arrays.asList(1, 2, 3), first);
+
+        // Second parse with the same byte[] instance and AUTO_CLOSE_SOURCE disabled.
+        // The byte[] source always triggers an unpacker reset (|| src instanceof byte[]),
+        // so the second parse succeeds and returns the correct result.
+        List<Integer> second = objectMapper.readValue(bytes, new TypeReference<List<Integer>>() {});
+        assertEquals(Arrays.asList(1, 2, 3), second);
+    }
+
+    @Test
+    public void testInputStreamSequentialReadsWithAutoCloseSourceDisabled()
+            throws IOException
+    {
+        ObjectMapper objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .disable(tools.jackson.core.StreamReadFeature.AUTO_CLOSE_SOURCE)
+                .disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .build();
+
+        // Two values packed sequentially into a single stream
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(objectMapper.writeValueAsBytes(Arrays.asList(1, 2, 3)));
+        out.write(objectMapper.writeValueAsBytes(Arrays.asList(4, 5, 6)));
+        ByteArrayInputStream stream = new ByteArrayInputStream(out.toByteArray());
+
+        // First parse reads the first value; unpacker may read ahead into the second value
+        List<Integer> first = objectMapper.readValue(stream, new TypeReference<List<Integer>>() {});
+        assertEquals(Arrays.asList(1, 2, 3), first);
+
+        // Second parse must read the second value from the same stream.
+        // If the source was incorrectly cleared from the ThreadLocal on close(),
+        // the unpacker's read-ahead buffer is dismissed and the second value is lost.
+        List<Integer> second = objectMapper.readValue(stream, new TypeReference<List<Integer>>() {});
+        assertEquals(Arrays.asList(4, 5, 6), second);
+    }
+
+    @Test
+    public void testGetStringOnNullToken() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packNil();
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NULL, p.nextToken());
+            assertEquals("null", p.getString());
+        }
+    }
+
+    @Test
+    public void testGetStringOnBoolToken() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packBoolean(true);
+            packer.packBoolean(false);
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_TRUE, p.nextToken());
+            assertEquals("true", p.getString());
+            assertEquals(JsonToken.VALUE_FALSE, p.nextToken());
+            assertEquals("false", p.getString());
+        }
+    }
+
+    @Test
+    public void testNumericAccessorsOnNullTokenThrow() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packNil();
+        }
+        byte[] bytes = out.toByteArray();
+        MessagePackFactory factory = new MessagePackFactory();
+
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getIntValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getLongValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getDoubleValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getFloatValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getBigIntegerValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getDecimalValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getNumberValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+    }
+
+    @Test
+    public void testNumericAccessorsOnBoolTokenThrow() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packBoolean(true);
+        }
+        byte[] bytes = out.toByteArray();
+        MessagePackFactory factory = new MessagePackFactory();
+
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getIntValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getLongValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            p.nextToken();
+            try {
+                p.getDoubleValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+        }
+    }
+
+    @Test
+    public void testGetNumberTypeOnNonNumericTokens() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packNil();
+            packer.packBoolean(true);
+            packer.packString("hello");
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NULL, p.nextToken());
+            assertNull(p.getNumberType());
+            assertEquals(JsonToken.VALUE_TRUE, p.nextToken());
+            assertNull(p.getNumberType());
+            assertEquals(JsonToken.VALUE_STRING, p.nextToken());
+            assertNull(p.getNumberType());
+        }
+    }
+
+    @Test
+    public void testGetIntValueFromOutOfRangeDoubleThrows() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packDouble(1e30);
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            try {
+                p.getIntValue();
+                fail("expected exception for out-of-range double");
+            }
+            catch (JacksonException ignored) { }
+        }
+    }
+
+    @Test
+    public void testGetLongValueFromOutOfRangeDoubleThrows() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packDouble(1e30);
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            try {
+                p.getLongValue();
+                fail("expected exception for out-of-range double");
+            }
+            catch (JacksonException ignored) { }
+        }
+    }
+
+    @Test
+    public void testGetLongValueFromDoubleThatEqualsLongMaxValueRoundedUpThrows() throws IOException
+    {
+        // (double) Long.MAX_VALUE rounds up to 2^63, which exceeds Long.MAX_VALUE.
+        // The check `doubleValue > Long.MAX_VALUE` misses this value and silently
+        // saturates the cast to Long.MAX_VALUE instead of throwing.
+        double twoTo63 = 9.223372036854776E18; // exact double for 2^63
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packDouble(twoTo63);
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            try {
+                p.getLongValue();
+                fail("expected exception for double value 2^63 which exceeds Long.MAX_VALUE");
+            }
+            catch (JacksonException ignored) { }
+        }
+    }
+
+    @Test
+    public void testNumericAccessorsOnStructuralTokenThrow() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packMapHeader(0);
+        }
+        byte[] bytes = out.toByteArray();
+        MessagePackFactory factory = new MessagePackFactory();
+
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), bytes)) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            try {
+                p.getIntValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            try {
+                p.getLongValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            try {
+                p.getDoubleValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            try {
+                p.getFloatValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            try {
+                p.getBigIntegerValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            try {
+                p.getDecimalValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            try {
+                p.getNumberValue();
+                fail("expected exception");
+            }
+            catch (JacksonException ignored) { }
+            assertNull(p.getNumberType());
+        }
+    }
+
+    @Test
+    public void testGetIntValueFromFractionalDoubleTruncates() throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(out)) {
+            packer.packDouble(3.7);
+        }
+        MessagePackFactory factory = new MessagePackFactory();
+        try (JsonParser p = factory.createParser(ObjectReadContext.empty(), out.toByteArray())) {
+            assertEquals(JsonToken.VALUE_NUMBER_FLOAT, p.nextToken());
+            assertEquals(3, p.getIntValue());
+        }
+    }
+
+    // Bug: MessagePackParser.close() has no re-entrancy guard; the base-class
+    // "if (_closed) { return; }" is bypassed because close() is fully overridden
+    // without calling super.  A second call re-enters _closeInput(), which closes
+    // the underlying InputStream a second time.
+    @Test
+    public void testParserCloseIsIdempotent() throws IOException
+    {
+        byte[] bytes = objectMapper.writeValueAsBytes(42);
+        final int[] closeCount = {0};
+        InputStream trackingStream = new ByteArrayInputStream(bytes) {
+            @Override
+            public void close() throws IOException
+            {
+                closeCount[0]++;
+                super.close();
+            }
+        };
+
+        // reuseResourceInParser=false keeps ThreadLocal out of the picture so the
+        // test isolates the re-entrancy guard in close() itself.
+        MessagePackFactory nonReuseFactory =
+                new MessagePackFactory().setReuseResourceInParser(false);
+        JsonParser parser =
+                nonReuseFactory.createParser(ObjectReadContext.empty(), trackingStream);
+        parser.nextToken();
+        parser.close();  // first close
+        parser.close();  // Bug: calls _closeInput() again — stream closed twice
+
+        assertEquals("Stream should be closed exactly once", 1, closeCount[0]);
+    }
+
+    // Bug: DupDetector.isDup(null) throws NullPointerException when a nil map key
+    // follows a non-null key and STRICT_DUPLICATE_DETECTION is enabled.
+    // The fault: name.equals(_firstName) where name is null and _firstName holds
+    // the prior non-null key string → NullPointerException.
+    @Test
+    public void testNilMapKeyWithDupDetectionDoesNotNPE() throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(baos)) {
+            packer.packMapHeader(2);
+            packer.packString("foo");
+            packer.packInt(1);
+            packer.packNil();    // nil key — triggers DupDetector.isDup(null)
+            packer.packInt(2);
+        }
+
+        MessagePackFactory f = new MessagePackFactoryBuilder()
+                .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                .build();
+
+        try (JsonParser p = f.createParser(ObjectReadContext.empty(), baos.toByteArray())) {
+            assertEquals(JsonToken.START_OBJECT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken());
+            assertEquals("foo", p.currentName());
+            assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(JsonToken.PROPERTY_NAME, p.nextToken()); // Bug: NPE here
+            assertNull(p.currentName());
+            assertEquals(JsonToken.VALUE_NUMBER_INT, p.nextToken());
+            assertEquals(JsonToken.END_OBJECT, p.nextToken());
+        }
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackWriteContextTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/MessagePackWriteContextTest.java
@@ -1,0 +1,230 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.ObjectWriteContext;
+import tools.jackson.core.TokenStreamContext;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class MessagePackWriteContextTest
+{
+    private final MessagePackFactory factory = new MessagePackFactory();
+
+    @Test
+    public void testRootContext()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            TokenStreamContext ctx = gen.streamWriteContext();
+            assertTrue(ctx.inRoot());
+            assertFalse(ctx.inArray());
+            assertFalse(ctx.inObject());
+            assertNull(ctx.currentName());
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(0, ctx.getEntryCount());
+            assertNull(ctx.getParent());
+            gen.writeNumber(1);
+        }
+    }
+
+    @Test
+    public void testArrayContext()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            gen.writeStartArray();
+            TokenStreamContext ctx = gen.streamWriteContext();
+
+            assertFalse(ctx.inRoot());
+            assertTrue(ctx.inArray());
+            assertFalse(ctx.inObject());
+            assertNull(ctx.currentName());
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(0, ctx.getEntryCount());
+            assertNotNull(ctx.getParent());
+            assertTrue(ctx.getParent().inRoot());
+
+            gen.writeNumber(1);
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(1, ctx.getEntryCount());
+
+            gen.writeNumber(2);
+            assertEquals(1, ctx.getCurrentIndex());
+            assertEquals(2, ctx.getEntryCount());
+
+            gen.writeNumber(3);
+            assertEquals(2, ctx.getCurrentIndex());
+            assertEquals(3, ctx.getEntryCount());
+
+            gen.writeEndArray();
+            assertTrue(gen.streamWriteContext().inRoot());
+        }
+    }
+
+    @Test
+    public void testObjectContext()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            gen.writeStartObject();
+            TokenStreamContext ctx = gen.streamWriteContext();
+
+            assertFalse(ctx.inRoot());
+            assertFalse(ctx.inArray());
+            assertTrue(ctx.inObject());
+            assertNull(ctx.currentName());
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(0, ctx.getEntryCount());
+
+            gen.writeName("first");
+            assertEquals("first", ctx.currentName());
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(0, ctx.getEntryCount());
+
+            gen.writeNumber(1);
+            assertEquals("first", ctx.currentName());
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(1, ctx.getEntryCount());
+
+            gen.writeName("second");
+            assertEquals("second", ctx.currentName());
+            assertEquals(0, ctx.getCurrentIndex());
+            assertEquals(1, ctx.getEntryCount());
+
+            gen.writeString("value");
+            assertEquals(1, ctx.getCurrentIndex());
+            assertEquals(2, ctx.getEntryCount());
+
+            gen.writeEndObject();
+            assertTrue(gen.streamWriteContext().inRoot());
+        }
+    }
+
+    @Test
+    public void testNestedObjectInArray()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            gen.writeStartArray();
+            TokenStreamContext arrayCtx = gen.streamWriteContext();
+            assertTrue(arrayCtx.inArray());
+
+            gen.writeStartObject();
+            TokenStreamContext objectCtx = gen.streamWriteContext();
+            assertTrue(objectCtx.inObject());
+            assertSame(arrayCtx, objectCtx.getParent());
+
+            gen.writeName("key");
+            assertEquals("key", objectCtx.currentName());
+            assertEquals("key", gen.streamWriteContext().currentName());
+
+            gen.writeNumber(42);
+            gen.writeEndObject();
+
+            assertSame(arrayCtx, gen.streamWriteContext());
+            assertEquals(0, arrayCtx.getCurrentIndex());
+            assertEquals(1, arrayCtx.getEntryCount());
+
+            gen.writeEndArray();
+        }
+    }
+
+    @Test
+    public void testCurrentValue()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            Object pojo = new Object();
+            gen.writeStartObject(pojo);
+            TokenStreamContext ctx = gen.streamWriteContext();
+            assertEquals(pojo, ctx.currentValue());
+
+            Object inner = new Object();
+            gen.writeName("arr");
+            gen.writeStartArray(inner);
+            assertEquals(inner, gen.streamWriteContext().currentValue());
+            gen.writeEndArray();
+
+            gen.writeEndObject();
+        }
+    }
+
+    @Test
+    public void testChildContextIsReused()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            gen.writeStartArray();
+
+            gen.writeStartObject();
+            TokenStreamContext first = gen.streamWriteContext();
+            gen.writeName("k");
+            gen.writeNumber(1);
+            gen.writeEndObject();
+
+            gen.writeStartObject();
+            TokenStreamContext second = gen.streamWriteContext();
+            assertSame(first, second);
+            assertNull(second.currentName());
+            assertEquals(0, second.getCurrentIndex());
+            assertEquals(0, second.getEntryCount());
+
+            gen.writeName("k2");
+            gen.writeNumber(2);
+            gen.writeEndObject();
+
+            gen.writeEndArray();
+        }
+    }
+
+    @Test
+    public void testAssignCurrentValue()
+            throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JsonGenerator gen = factory.createGenerator(ObjectWriteContext.empty(), baos)) {
+            gen.writeStartObject();
+            TokenStreamContext ctx = gen.streamWriteContext();
+            assertNull(ctx.currentValue());
+
+            Object v = new Object();
+            gen.assignCurrentValue(v);
+            assertSame(v, ctx.currentValue());
+            assertSame(v, gen.currentValue());
+
+            gen.writeName("k");
+            gen.writeNumber(1);
+            gen.writeEndObject();
+        }
+    }
+}

--- a/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/TimestampExtensionModuleTest.java
+++ b/msgpack-jackson3/src/test/java/org/msgpack/jackson/dataformat/TimestampExtensionModuleTest.java
@@ -1,0 +1,217 @@
+//
+// MessagePack for Java
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+package org.msgpack.jackson.dataformat;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimestampExtensionModuleTest
+{
+    private ObjectMapper objectMapper;
+    private final SingleInstant singleInstant = new SingleInstant();
+    private final TripleInstants tripleInstants = new TripleInstants();
+
+    private static class SingleInstant
+    {
+        public Instant instant;
+    }
+
+    private static class TripleInstants
+    {
+        public Instant a;
+        public Instant b;
+        public Instant c;
+    }
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        objectMapper = MessagePackMapper.builder(new MessagePackFactory())
+                .addModule(TimestampExtensionModule.INSTANCE)
+                .build();
+    }
+
+    @Test
+    public void testSingleInstantPojo()
+            throws IOException
+    {
+        singleInstant.instant = Instant.now();
+        byte[] bytes = objectMapper.writeValueAsBytes(singleInstant);
+        SingleInstant deserialized = objectMapper.readValue(bytes, SingleInstant.class);
+        assertEquals(singleInstant.instant, deserialized.instant);
+    }
+
+    @Test
+    public void testTripleInstantsPojo()
+            throws IOException
+    {
+        Instant now = Instant.now();
+        tripleInstants.a = now.minusSeconds(1);
+        tripleInstants.b = now;
+        tripleInstants.c = now.plusSeconds(1);
+        byte[] bytes = objectMapper.writeValueAsBytes(tripleInstants);
+        TripleInstants deserialized = objectMapper.readValue(bytes, TripleInstants.class);
+        assertEquals(now.minusSeconds(1), deserialized.a);
+        assertEquals(now, deserialized.b);
+        assertEquals(now.plusSeconds(1), deserialized.c);
+    }
+
+    @Test
+    public void serialize32BitFormat()
+            throws IOException
+    {
+        singleInstant.instant = Instant.ofEpochSecond(Instant.now().getEpochSecond());
+
+        byte[] bytes = objectMapper.writeValueAsBytes(singleInstant);
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            assertEquals("instant", unpacker.unpackString());
+            assertEquals(4, unpacker.unpackExtensionTypeHeader().getLength());
+        }
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            unpacker.unpackString();
+            assertEquals(singleInstant.instant, unpacker.unpackTimestamp());
+        }
+    }
+
+    @Test
+    public void serialize64BitFormat()
+            throws IOException
+    {
+        singleInstant.instant = Instant.ofEpochSecond(Instant.now().getEpochSecond(), 1234);
+
+        byte[] bytes = objectMapper.writeValueAsBytes(singleInstant);
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            assertEquals("instant", unpacker.unpackString());
+            assertEquals(8, unpacker.unpackExtensionTypeHeader().getLength());
+        }
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            unpacker.unpackString();
+            assertEquals(singleInstant.instant, unpacker.unpackTimestamp());
+        }
+    }
+
+    @Test
+    public void serialize96BitFormat()
+            throws IOException
+    {
+        singleInstant.instant = Instant.ofEpochSecond(19880866800L /* 2600-01-01 */, 1234);
+
+        byte[] bytes = objectMapper.writeValueAsBytes(singleInstant);
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            assertEquals("instant", unpacker.unpackString());
+            assertEquals(12, unpacker.unpackExtensionTypeHeader().getLength());
+        }
+
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            unpacker.unpackString();
+            assertEquals(singleInstant.instant, unpacker.unpackTimestamp());
+        }
+    }
+
+    @Test
+    public void deserialize32BitFormat()
+            throws IOException
+    {
+        Instant instant = Instant.ofEpochSecond(Instant.now().getEpochSecond());
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(os)) {
+            packer.packMapHeader(1)
+                    .packString("instant")
+                    .packTimestamp(instant);
+        }
+
+        byte[] bytes = os.toByteArray();
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            unpacker.unpackString();
+            assertEquals(4, unpacker.unpackExtensionTypeHeader().getLength());
+        }
+
+        SingleInstant deserialized = objectMapper.readValue(bytes, SingleInstant.class);
+        assertEquals(instant, deserialized.instant);
+    }
+
+    @Test
+    public void deserialize64BitFormat()
+            throws IOException
+    {
+        Instant instant = Instant.ofEpochSecond(Instant.now().getEpochSecond(), 1234);
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(os)) {
+            packer.packMapHeader(1)
+                    .packString("instant")
+                    .packTimestamp(instant);
+        }
+
+        byte[] bytes = os.toByteArray();
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            unpacker.unpackString();
+            assertEquals(8, unpacker.unpackExtensionTypeHeader().getLength());
+        }
+
+        SingleInstant deserialized = objectMapper.readValue(bytes, SingleInstant.class);
+        assertEquals(instant, deserialized.instant);
+    }
+
+    @Test
+    public void deserialize96BitFormat()
+            throws IOException
+    {
+        Instant instant = Instant.ofEpochSecond(19880866800L /* 2600-01-01 */, 1234);
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        try (MessagePacker packer = MessagePack.newDefaultPacker(os)) {
+            packer.packMapHeader(1)
+                    .packString("instant")
+                    .packTimestamp(instant);
+        }
+
+        byte[] bytes = os.toByteArray();
+        try (MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(bytes)) {
+            unpacker.unpackMapHeader();
+            unpacker.unpackString();
+            assertEquals(12, unpacker.unpackExtensionTypeHeader().getLength());
+        }
+
+        SingleInstant deserialized = objectMapper.readValue(bytes, SingleInstant.class);
+        assertEquals(instant, deserialized.instant);
+    }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-jcheckstyle" % "0.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-osgi"        % "0.10.0")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.6.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"      % "5.1.1")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"     % "0.4.7")
 
 scalacOptions ++= Seq("-deprecation", "-feature")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-jcheckstyle" % "0.3.0")
 addSbtPlugin("com.github.sbt" % "sbt-osgi"        % "0.11.0-RC1")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.6.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver"      % "5.1.1")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh"     % "0.4.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"     % "0.4.8")
 
 scalacOptions ++= Seq("-deprecation", "-feature")


### PR DESCRIPTION
## Summary

- Adds a new `msgpack-jackson3` submodule (`jackson-dataformat-msgpack3`) that ports the existing Jackson 2.x integration to Jackson 3.x (`tools.jackson` namespace)
- Requires Java 17+ and Jackson 3.1.2; the module is excluded from the build on older JDKs so existing Java 8 users are unaffected
- Includes JMH benchmarks (`src/jmh/java`) runnable via `./sbt "msgpack-jackson3/jmh:run"`
- Fixes https://github.com/msgpack/msgpack-java/issues/933

## Key differences from `msgpack-jackson`

- Package namespace: `com.fasterxml.jackson` → `tools.jackson`
- `TokenStreamLocation` replaces `JsonLocation`; byte offset passed as `columnNr`
- Lightweight `MessagePackWriteContext` replaces `SimpleStreamWriteContext`
