### PR TITLE
Pin JUnit to 5.x for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,8 @@
+# JUnit 6.x requires Java 17 at runtime, but this project still targets and
+# tests on JDK 8 (see javacOptions in build.sbt and the test matrix in
+# .github/workflows/CI.yml). Pin JUnit to the 5.x line until JDK 8 support is
+# dropped.
+updates.pin = [
+  { groupId = "org.junit.jupiter", artifactId = "junit-jupiter", version = "5." },
+  { groupId = "org.junit.vintage", artifactId = "junit-vintage-engine", version = "5." }
+]


### PR DESCRIPTION
## Summary
- Add `.scala-steward.conf` pinning `junit-jupiter` and `junit-vintage-engine` to the 5.x line.
- JUnit 6.x requires Java 17 at runtime, but this project still targets Java 8 bytecode (`javacOptions += -source 1.8 -target 1.8` in `build.sbt`) and CI tests against JDK 8 in the matrix.
- Closes the situation behind #994 and #995 (both closed) so Scala Steward stops re-proposing 6.x bumps until JDK 8 support is dropped.

## Test plan
- [ ] CI passes (no behavior change — config-only)